### PR TITLE
Refactoring: variadic functions & psalmphp

### DIFF
--- a/src/EdifactParser.php
+++ b/src/EdifactParser.php
@@ -9,7 +9,6 @@ use EdifactParser\Exception\InvalidFile;
 use EdifactParser\Segments\SegmentFactory;
 use EdifactParser\Segments\SegmentFactoryInterface;
 
-/** @psalmphp-immutable */
 final class EdifactParser
 {
     private SegmentFactoryInterface $segmentFactory;

--- a/src/Exception/InvalidFile.php
+++ b/src/Exception/InvalidFile.php
@@ -7,7 +7,6 @@ namespace EdifactParser\Exception;
 use Exception;
 use function json_encode;
 
-/** @psalmphp-immutable */
 final class InvalidFile extends Exception
 {
     public static function withErrors(array $errors): self

--- a/src/SegmentedValues.php
+++ b/src/SegmentedValues.php
@@ -8,7 +8,6 @@ use EdifactParser\Segments\SegmentFactory;
 use EdifactParser\Segments\SegmentFactoryInterface;
 use EdifactParser\Segments\SegmentInterface;
 
-/** @psalmphp-immutable */
 final class SegmentedValues
 {
     /** @psalm-var list<SegmentInterface> */

--- a/src/Segments/BGMBeginningOfMessage.php
+++ b/src/Segments/BGMBeginningOfMessage.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class BGMBeginningOfMessage implements SegmentInterface
 {
     private array $rawValues;

--- a/src/Segments/CNTControl.php
+++ b/src/Segments/CNTControl.php
@@ -6,7 +6,6 @@ namespace EdifactParser\Segments;
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class CNTControl implements SegmentInterface
 {
     private array $rawValues;

--- a/src/Segments/DTMDateTimePeriod.php
+++ b/src/Segments/DTMDateTimePeriod.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class DTMDateTimePeriod implements SegmentInterface
 {
     private array $rawValues;

--- a/src/Segments/MEADimensions.php
+++ b/src/Segments/MEADimensions.php
@@ -6,7 +6,6 @@ namespace EdifactParser\Segments;
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class MEADimensions implements SegmentInterface
 {
     private array $rawValues;

--- a/src/Segments/NADNameAddress.php
+++ b/src/Segments/NADNameAddress.php
@@ -6,7 +6,6 @@ namespace EdifactParser\Segments;
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class NADNameAddress implements SegmentInterface
 {
     private array $rawValues;

--- a/src/Segments/PCIPackageId.php
+++ b/src/Segments/PCIPackageId.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class PCIPackageId implements SegmentInterface
 {
     private array $rawValues;

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class SegmentFactory implements SegmentFactoryInterface
 {
     public function segmentFromArray(array $rawArray): SegmentInterface

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -9,9 +9,7 @@ final class SegmentFactory implements SegmentFactoryInterface
 {
     public function segmentFromArray(array $rawArray): SegmentInterface
     {
-        $name = $rawArray[0];
-
-        switch ($name) {
+        switch ($rawArray[0]) {
             case 'UNH':
                 return new UNHMessageHeader($rawArray);
             case 'DTM':

--- a/src/Segments/UNHMessageHeader.php
+++ b/src/Segments/UNHMessageHeader.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class UNHMessageHeader implements SegmentInterface
 {
     private array $rawValues;

--- a/src/Segments/UNTMessageFooter.php
+++ b/src/Segments/UNTMessageFooter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class UNTMessageFooter implements SegmentInterface
 {
     private array $rawValues;

--- a/src/Segments/UnknownSegment.php
+++ b/src/Segments/UnknownSegment.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EdifactParser\Segments;
 
-/** @psalmphp-immutable */
 final class UnknownSegment implements SegmentInterface
 {
     private array $rawValues;

--- a/src/TransactionMessage.php
+++ b/src/TransactionMessage.php
@@ -17,11 +17,15 @@ final class TransactionMessage
      */
     private array $segments = [];
 
-    public function __construct(array $segments = [])
+    public static function withSegments(SegmentInterface...$segments): self
     {
+        $self = new self();
+
         foreach ($segments as $segment) {
-            $this->addSegment($segment);
+            $self->addSegment($segment);
         }
+
+        return $self;
     }
 
     public function addSegment(SegmentInterface $segment): void

--- a/src/TransactionMessage.php
+++ b/src/TransactionMessage.php
@@ -6,7 +6,6 @@ namespace EdifactParser;
 
 use EdifactParser\Segments\SegmentInterface;
 
-/** @psalmphp-immutable */
 final class TransactionMessage
 {
     /**

--- a/src/TransactionResult.php
+++ b/src/TransactionResult.php
@@ -8,8 +8,6 @@ use EdifactParser\Segments\UNHMessageHeader;
 
 /**
  * A transactionResult is a list of transactionMessages.
- *
- * @psalmphp-immutable
  */
 final class TransactionResult
 {

--- a/src/TransactionResult.php
+++ b/src/TransactionResult.php
@@ -33,7 +33,6 @@ final class TransactionResult
                 if ($message) {
                     $messages[] = $message;
                 }
-
                 $message = new TransactionMessage();
             }
 

--- a/tests/Unit/SegmentedValuesTest.php
+++ b/tests/Unit/SegmentedValuesTest.php
@@ -6,22 +6,33 @@ namespace EdifactParser\Tests\Unit;
 
 use EDI\Parser;
 use EdifactParser\SegmentedValues;
-use EdifactParser\Segments\SegmentFactory;
+use EdifactParser\Segments\CNTControl;
 use EdifactParser\Segments\UNHMessageHeader;
 use PHPUnit\Framework\TestCase;
 
 final class SegmentedValuesTest extends TestCase
 {
     /** @test */
-    public function getListOfSegments(): void
+    public function listWithOneSegment(): void
     {
-        $fileContent = "UNH+1+IFTMIN:S:93A:UN:PN001'\nUNH+2+IFTMIN:S:93A:UN:PN001'";
-        $parser = new Parser($fileContent);
-        $values = (new SegmentedValues(new SegmentFactory()))->fromRaw($parser->get());
+        $fileContent = "UNH+1+IFTMIN:S:93A:UN:PN001'";
+        $values = SegmentedValues::factory()->fromRaw((new Parser($fileContent))->get());
 
         self::assertEquals([
             new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
-            new UNHMessageHeader(['UNH', '2', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
+        ], $values->list());
+    }
+
+    /** @test */
+    public function listWithMultipleSegments(): void
+    {
+        $fileContent = "UNH+1+IFTMIN:S:1A:UN:P1'\nUNH+2+IFTMIN:R:2A:UN:P2'\nCNT+7:0.1:KGM'";
+        $values = SegmentedValues::factory()->fromRaw((new Parser($fileContent))->get());
+
+        self::assertEquals([
+            new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '1A', 'UN', 'P1']]),
+            new UNHMessageHeader(['UNH', '2', ['IFTMIN', 'R', '2A', 'UN', 'P2']]),
+            new CNTControl(['CNT', ['7', '0.1', 'KGM']]),
         ], $values->list());
     }
 }

--- a/tests/Unit/TransactionMessageTest.php
+++ b/tests/Unit/TransactionMessageTest.php
@@ -16,10 +16,10 @@ final class TransactionMessageTest extends TestCase
     /** @test */
     public function twoSegmentsWithDifferentNames(): void
     {
-        $message = new TransactionMessage([
+        $message = TransactionMessage::withSegments(
             new CNTControl(['CNT', ['7', '0.1', 'KGM']]),
             new MEADimensions(['MEA', 'WT', 'G', ['KGM', '0.1']]),
-        ]);
+        );
 
         self::assertEquals([
             CNTControl::class => [
@@ -34,12 +34,12 @@ final class TransactionMessageTest extends TestCase
     /** @test */
     public function twoSegmentsWithTheSameName(): void
     {
-        $message = new TransactionMessage([
+        $message = TransactionMessage::withSegments(
             new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
             new UNTMessageFooter(['UNT', '19', '1']),
             new MEADimensions(['MEA', 'WT', 'G', ['KGM', '0.1']]),
             new MEADimensions(['MEA', 'VOL', '', ['MTQ', '0.06822']]),
-        ]);
+        );
 
         self::assertEquals([
             UNHMessageHeader::class => [
@@ -58,13 +58,13 @@ final class TransactionMessageTest extends TestCase
     /** @test */
     public function moreThanTwoSegmentsWithTheSameName(): void
     {
-        $message = new TransactionMessage([
+        $message = TransactionMessage::withSegments(
             new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
             new UNTMessageFooter(['UNT', '19', '1']),
             new CNTControl(['CNT', ['7', '0.1', 'KGM']]),
             new CNTControl(['CNT', ['11', '1', 'PCE']]),
             new CNTControl(['CNT', ['15', '0.068224', 'MTQ']]),
-        ]);
+        );
 
         self::assertEquals([
             UNHMessageHeader::class => [

--- a/tests/Unit/TransactionResultTest.php
+++ b/tests/Unit/TransactionResultTest.php
@@ -22,10 +22,10 @@ final class TransactionResultTest extends TestCase
         $fileContent = "UNH+1+IFTMIN:S:93A:UN:PN001'\nUNT+19+1'";
 
         self::assertEquals([
-            new TransactionMessage([
+            TransactionMessage::withSegments(
                 new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
                 new UNTMessageFooter(['UNT', '19', '1']),
-            ]),
+            ),
         ], $this->resultFactory($fileContent)->messages());
     }
 
@@ -41,15 +41,15 @@ UNT+19+2'
 UNZ+2+3'
 EDI;
         self::assertEquals([
-            new TransactionMessage([
+            TransactionMessage::withSegments(
                 new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
                 new UNTMessageFooter(['UNT', '19', '1']),
-            ]),
-            new TransactionMessage([
+            ),
+            TransactionMessage::withSegments(
                 new UNHMessageHeader(['UNH', '2', ['IFTMIN', 'S', '94A', 'UN', 'PN002']]),
                 new UNTMessageFooter(['UNT', '19', '2']),
                 new UnknownSegment(['UNZ', '2', '3']),
-            ]),
+            ),
         ], $this->resultFactory($fileContent)->messages());
     }
 
@@ -66,14 +66,14 @@ UNT+19+1'
 UNZ+2+3'
 EDI;
         self::assertEquals([
-            new TransactionMessage([
+            TransactionMessage::withSegments(
                 new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
                 new UNTMessageFooter(['UNT', '19', '1']),
                 new CNTControl(['CNT', ['7', '0.1', 'KGM']]),
                 new CNTControl(['CNT', ['11', '1', 'PCE']]),
                 new CNTControl(['CNT', ['15', '0.068224', 'MTQ']]),
                 new UnknownSegment(['UNZ', '2', '3']),
-            ]),
+            ),
         ], $this->resultFactory($fileContent)->messages());
     }
 

--- a/tests/Unit/TransactionResultTest.php
+++ b/tests/Unit/TransactionResultTest.php
@@ -21,16 +21,12 @@ final class TransactionResultTest extends TestCase
     {
         $fileContent = "UNH+1+IFTMIN:S:93A:UN:PN001'\nUNT+19+1'";
 
-        $result = TransactionResult::fromSegmentedValues(
-            SegmentedValues::factory()->fromRaw((new Parser($fileContent))->get())
-        );
-
         self::assertEquals([
             new TransactionMessage([
                 new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
                 new UNTMessageFooter(['UNT', '19', '1']),
             ]),
-        ], $result->messages());
+        ], $this->resultFactory($fileContent)->messages());
     }
 
     /** @test */
@@ -44,10 +40,6 @@ UNH+2+IFTMIN:S:94A:UN:PN002'
 UNT+19+2'
 UNZ+2+3'
 EDI;
-        $result = TransactionResult::fromSegmentedValues(
-            SegmentedValues::factory()->fromRaw((new Parser($fileContent))->get())
-        );
-
         self::assertEquals([
             new TransactionMessage([
                 new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
@@ -58,7 +50,7 @@ EDI;
                 new UNTMessageFooter(['UNT', '19', '2']),
                 new UnknownSegment(['UNZ', '2', '3']),
             ]),
-        ], $result->messages());
+        ], $this->resultFactory($fileContent)->messages());
     }
 
     /** @test */
@@ -73,10 +65,6 @@ CNT+15:0.068224:MTQ'
 UNT+19+1'
 UNZ+2+3'
 EDI;
-        $result = TransactionResult::fromSegmentedValues(
-            SegmentedValues::factory()->fromRaw((new Parser($fileContent))->get())
-        );
-
         self::assertEquals([
             new TransactionMessage([
                 new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
@@ -86,6 +74,13 @@ EDI;
                 new CNTControl(['CNT', ['15', '0.068224', 'MTQ']]),
                 new UnknownSegment(['UNZ', '2', '3']),
             ]),
-        ], $result->messages());
+        ], $this->resultFactory($fileContent)->messages());
+    }
+
+    private function resultFactory(string $fileContent): TransactionResult
+    {
+        return TransactionResult::fromSegmentedValues(
+            SegmentedValues::factory()->fromRaw((new Parser($fileContent))->get())
+        );
     }
 }


### PR DESCRIPTION
# Description

- Using variadic functions refactoring
- Cleaning some tests
- Remove the wrong property`@psalmphp-immutable`, it should be [@psalm-immutable](https://psalm.dev/articles/immutability-and-beyond) It will be done in another branch because it's not possible to apply it to all the classes because not all of them are pure (which means they don't have side effects).