### PR TITLE
Replace an array_map by a foreach in SegmentFactory

### DIFF
--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -55,8 +55,6 @@ final class SegmentFactory implements SegmentFactoryInterface
     /** @param array<string,string> $segments */
     private function __construct(array $segments)
     {
-        Assert::allLength(array_keys($segments), self::TAG_LENGTH);
-
         foreach ($segments as $tag => $class) {
             Assert::length($tag, self::TAG_LENGTH);
             if (!$this->classImplements($class, SegmentInterface::class)) {

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -57,11 +57,12 @@ final class SegmentFactory implements SegmentFactoryInterface
     {
         Assert::allLength(array_keys($segments), self::TAG_LENGTH);
 
-        array_map(function (string $class): void {
+        foreach ($segments as $tag => $class) {
+            Assert::length($tag, self::TAG_LENGTH);
             if (!$this->classImplements($class, SegmentInterface::class)) {
                 throw new InvalidArgumentException("'{$class}' must implements 'SegmentInterface'");
             }
-        }, $segments);
+        }
 
         $this->segments = $segments;
     }


### PR DESCRIPTION
## Description

`array_map` is useful when we want to "map" (transform) one array into another applying certain logic.
In this particular case, you don't expect the resultant array of the mapping operation.
For this reason, I think it is much better and clean just using a `foreach` loop.