### PR TITLE
Improve the handling of unknown segments

### DIFF
--- a/src/Segments/UnknownSegment.php
+++ b/src/Segments/UnknownSegment.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EdifactParser\Segments;
 
+use function is_string;
+
 /** @psalm-immutable */
 final class UnknownSegment implements SegmentInterface
 {
@@ -16,18 +18,30 @@ final class UnknownSegment implements SegmentInterface
 
     public function tag(): string
     {
-        return 'Unknown';
+        return $this->rawValues[0];
     }
 
     public function subId(): string
     {
-        $encodedValues = json_encode($this->rawValues);
+        if (is_string($this->rawValues[1])) {
+            return $this->rawValues[1];
+        }
 
-        return ($encodedValues) ? md5($encodedValues) : md5(self::class);
+        if (is_string($this->rawValues[1][0])) {
+            return $this->rawValues[1][0];
+        }
+
+        return $this->hashContentsWithMD5();
     }
 
     public function rawValues(): array
     {
         return $this->rawValues;
+    }
+
+    private function hashContentsWithMD5(): string
+    {
+        $encodedValues = json_encode($this->rawValues);
+        return ($encodedValues) ? md5($encodedValues) : md5(self::class);
     }
 }

--- a/tests/Unit/Segments/UnknownSegmentTest.php
+++ b/tests/Unit/Segments/UnknownSegmentTest.php
@@ -14,11 +14,58 @@ final class UnknownSegmentTest extends TestCase
      */
     public function segment_values(): void
     {
-        $rawValues = ['UNKNOWN', 'SEGMENT'];
+        $rawValues = ['UNKNOWN', ['some_sub_id', 'data', 'more_data']];
         $segment = new UnknownSegment($rawValues);
 
-        self::assertEquals('Unknown', $segment->tag());
-        self::assertEquals(md5(json_encode($rawValues)), $segment->subId());
+        self::assertEquals('UNKNOWN', $segment->tag());
+        self::assertEquals('some_sub_id', $segment->subId());
         self::assertEquals($rawValues, $segment->rawValues());
+    }
+
+    /**
+     * @test
+     */
+    public function tag_always_returns_first_value(): void
+    {
+        self::assertEquals(
+            'TAG',
+            (new UnknownSegment(['TAG', 'sub_id']))->tag()
+        );
+        self::assertEquals(
+            'other_tag',
+            (new UnknownSegment(['other_tag', 'sub_id']))->tag()
+        );
+        self::assertEquals(
+            'THETAG',
+            (new UnknownSegment(['THETAG', 'sub_id']))->tag()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function sub_id_infers_sub_id_if_present(): void
+    {
+        self::assertEquals(
+            'other_sub_id',
+            (new UnknownSegment(['unknown', 'other_sub_id']))->subId()
+        );
+
+        self::assertEquals(
+            'yet_another_sub_id',
+            (new UnknownSegment(['unknown', ['yet_another_sub_id']]))->subId()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function sub_id_returns_hash_if_no_sub_id_present(): void
+    {
+        $rawValues = ['unknown', [['other_sub_id']]];
+        self::assertEquals(
+            md5(json_encode($rawValues)),
+            (new UnknownSegment($rawValues))->subId()
+        );
     }
 }


### PR DESCRIPTION
With this change, unknown segments, both within `lineItems` and outside, will get structured like normal segments do, i.e. for a message like this (keep in mind that `UNK` and `KUN` are intentionally used as tags for unknown segments):
```
UNA:+.? '
UNH+1+IFTMIN:S:93A:UN:PN001'
KUN+32:15'
LIN+1'
UNK+first+23'
LIN+2'
UNK+first+13'
UNS+S'
CNT+11:1:PCE'
UNT+19+1'
UNZ+1+3'
```
The result would be:
```
[
  'groupedSegments' => [
    ['UNH'] => [...],
    ['KUN'] => [
      '32' => UnknownSegment(...),
    ],
    ['UNS'] => [...],
    ['CNT'] => [...],
    ['UNT'] => [...],
  ]
  'lineItems' => [
    '1' => [
      'LIN' => ['1' => ...],
      'UNK' => ['first' => UnknownSegment(...)],
    ],
    '2'=> [
      'LIN' => ['2' => ...],
      'UNK' => ['first' => UnknownSegment(...)],
    ],
  ],
]
```