### PR TITLE
Nicer access to line items

### DIFF
--- a/src/HasRetrievableSegments.php
+++ b/src/HasRetrievableSegments.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser;
+
+use EdifactParser\Segments\SegmentInterface;
+
+trait HasRetrievableSegments
+{
+    /**
+     * @return array<string, array<string, SegmentInterface>>
+     */
+    abstract public function allSegments(): array;
+
+    /**
+     * @return array<string,SegmentInterface>
+     */
+    public function segmentsByTag(string $tag): array
+    {
+        return $this->allSegments()[$tag] ?? [];
+    }
+
+    public function segmentByTagAndSubId(string $tag, string $subId): ?SegmentInterface
+    {
+        return $this->allSegments()[$tag][$subId] ?? null;
+    }
+}

--- a/src/LineItem.php
+++ b/src/LineItem.php
@@ -6,7 +6,7 @@ namespace EdifactParser;
 
 use EdifactParser\Segments\SegmentInterface;
 
-class LineItem
+final class LineItem
 {
     use HasRetrievableSegments;
 

--- a/src/LineItem.php
+++ b/src/LineItem.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser;
+
+use EdifactParser\Segments\SegmentInterface;
+
+class LineItem
+{
+    use HasRetrievableSegments;
+
+    /**
+     * @param  array<string, array<string, SegmentInterface>>  $data
+     */
+    public function __construct(private array $data)
+    {
+    }
+
+    public function allSegments(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/MessageDataBuilder/Builder.php
+++ b/src/MessageDataBuilder/Builder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EdifactParser\MessageDataBuilder;
 
+use EdifactParser\LineItem;
 use EdifactParser\Segments\LINLineItem;
 use EdifactParser\Segments\SegmentInterface;
 use EdifactParser\Segments\UNSSectionControl;
@@ -40,9 +41,15 @@ class Builder
         return $this->buildWhereBuilderIs(SimpleBuilder::class);
     }
 
+    /**
+     * @returns array<LineItem>
+     */
     public function buildLineItems(): array
     {
-        return $this->buildWhereBuilderIs(DetailsSectionBuilder::class);
+        return array_map(
+            static fn ($data) => new LineItem($data),
+            $this->buildWhereBuilderIs(DetailsSectionBuilder::class),
+        );
     }
 
     /**

--- a/src/TransactionMessage.php
+++ b/src/TransactionMessage.php
@@ -58,9 +58,9 @@ final class TransactionMessage
         return $this->lineItems;
     }
 
-    public function lineItemById(string|int $lineItemId): LineItem
+    public function lineItemById(string|int $lineItemId): ?LineItem
     {
-        return $this->lineItems[(string) $lineItemId];
+        return $this->lineItems[(string) $lineItemId] ?? null;
     }
 
     /**

--- a/src/TransactionMessage.php
+++ b/src/TransactionMessage.php
@@ -58,9 +58,9 @@ final class TransactionMessage
         return $this->lineItems;
     }
 
-    public function lineItemById(string $lineItemId): LineItem
+    public function lineItemById(string|int $lineItemId): LineItem
     {
-        return $this->lineItems[$lineItemId];
+        return $this->lineItems[(string) $lineItemId];
     }
 
     /**

--- a/src/TransactionMessage.php
+++ b/src/TransactionMessage.php
@@ -12,9 +12,11 @@ use EdifactParser\Segments\UNTMessageFooter;
 /** @psalm-immutable */
 final class TransactionMessage
 {
+    use HasRetrievableSegments;
+
     /**
-     * @param  array<string, array<string,SegmentInterface>>  $groupedSegments
-     * @param  array<string, array<string, array<string, SegmentInterface>>>  $lineItems
+     * @param  array<string, array<string, SegmentInterface>>  $groupedSegments
+     * @param  array<string, LineItem>  $lineItems
      */
     public function __construct(
         private array $groupedSegments,
@@ -49,29 +51,24 @@ final class TransactionMessage
     }
 
     /**
-     * @return array<string, array<string,SegmentInterface>>
+     * @return array<string, LineItem>
      */
-    public function allSegments(): array
-    {
-        return $this->groupedSegments;
-    }
-
     public function lineItems(): array
     {
         return $this->lineItems;
     }
 
-    /**
-     * @return array<string,SegmentInterface>
-     */
-    public function segmentsByTag(string $tag): array
+    public function lineItemById(string $lineItemId): LineItem
     {
-        return $this->groupedSegments[$tag] ?? [];
+        return $this->lineItems[$lineItemId];
     }
 
-    public function segmentByTagAndSubId(string $tag, string $subId): ?SegmentInterface
+    /**
+     * @return array<string, array<string,SegmentInterface>>
+     */
+    public function allSegments(): array
     {
-        return $this->groupedSegments[$tag][$subId] ?? null;
+        return $this->groupedSegments;
     }
 
     /**

--- a/tests/Functional/EdifactParserTest.php
+++ b/tests/Functional/EdifactParserTest.php
@@ -147,7 +147,7 @@ EDI;
         $transactionResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
         $message = $transactionResult[0];
 
-        self::assertNotNull($message->lineItems()[1]['UNK']['first']);
-        self::assertNotNull($message->lineItems()[2]['UNK']['first']);
+        self::assertNotNull($message->lineItemById('1')->segmentByTagAndSubId('UNK', 'first'));
+        self::assertNotNull($message->lineItemById('2')->segmentByTagAndSubId('UNK', 'first'));
     }
 }

--- a/tests/Functional/EdifactParserTest.php
+++ b/tests/Functional/EdifactParserTest.php
@@ -147,7 +147,7 @@ EDI;
         $transactionResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
         $message = $transactionResult[0];
 
-        self::assertNotNull($message->lineItemById('1')->segmentByTagAndSubId('UNK', 'first'));
-        self::assertNotNull($message->lineItemById('2')->segmentByTagAndSubId('UNK', 'first'));
+        self::assertNotNull($message->lineItemById(1)->segmentByTagAndSubId('UNK', 'first'));
+        self::assertNotNull($message->lineItemById(2)->segmentByTagAndSubId('UNK', 'first'));
     }
 }

--- a/tests/Functional/EdifactParserTest.php
+++ b/tests/Functional/EdifactParserTest.php
@@ -147,7 +147,7 @@ EDI;
         $transactionResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
         $message = $transactionResult[0];
 
-        self::assertNotNull($message->lineItemById(1)->segmentByTagAndSubId('UNK', 'first'));
-        self::assertNotNull($message->lineItemById(2)->segmentByTagAndSubId('UNK', 'first'));
+        self::assertNotNull($message->lineItemById(1)?->segmentByTagAndSubId('UNK', 'first'));
+        self::assertNotNull($message->lineItemById(2)?->segmentByTagAndSubId('UNK', 'first'));
     }
 }

--- a/tests/Unit/MessageBuilder/MessageBuilderTest.php
+++ b/tests/Unit/MessageBuilder/MessageBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EdifactParser\Tests\Unit\MessageBuilder;
 
+use EdifactParser\LineItem;
 use EdifactParser\MessageDataBuilder\Builder as MessageDataBuilder;
 use EdifactParser\Segments\DTMDateTimePeriod;
 use EdifactParser\Segments\LINLineItem;
@@ -103,14 +104,14 @@ class MessageBuilderTest extends TestCase
         ], $builder->buildSegments());
 
         self::assertEquals([
-            '1' => [
+            '1' => new LineItem([
                 'LIN' => ['1' => $this->lineSegment],
                 'QTY' => ['21' => $this->quantitySegment],
-            ],
-            '2' => [
+            ]),
+            '2' => new LineItem([
                 'LIN' => ['2' => $this->otherLineSegment],
                 'QTY' => ['23' => $this->otherQuantitySegment],
-            ],
+            ]),
         ], $builder->buildLineItems());
     }
 
@@ -133,13 +134,13 @@ class MessageBuilderTest extends TestCase
         ], $builder->buildSegments());
 
         self::assertEquals([
-            '1' => [
+            '1' => new LineItem([
                 'LIN' => ['1' => $this->lineSegment],
                 'QTY' => [
                     '21' => $this->quantitySegment,
                     '23' => $this->otherQuantitySegment,
                 ],
-            ],
+            ]),
         ], $builder->buildLineItems());
     }
 }

--- a/tests/Unit/TransactionMessageTest.php
+++ b/tests/Unit/TransactionMessageTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EdifactParser\Tests\Unit;
 
 use EDI\Parser;
+use EdifactParser\LineItem;
 use EdifactParser\SegmentList;
 use EdifactParser\Segments\CNTControl;
 use EdifactParser\Segments\LINLineItem;
@@ -279,14 +280,14 @@ EDI;
         $firstMessage = reset($messages);
 
         self::assertEquals([
-            '1' => [
+            '1' => new LineItem([
                 'LIN' => ['1' => new LINLineItem(['LIN', 1])],
                 'QTY' => ['25' => new QTYQuantity(['QTY', [25, 5]])],
-            ],
-            '2' => [
+            ]),
+            '2' => new LineItem([
                 'LIN' => ['2' => new LINLineItem(['LIN', 2])],
                 'QTY' => ['23' => new QTYQuantity(['QTY', [23, 10]])],
-            ],
+            ]),
         ], $firstMessage->lineItems());
     }
 

--- a/tests/Unit/TransactionMessageTest.php
+++ b/tests/Unit/TransactionMessageTest.php
@@ -296,6 +296,7 @@ EDI;
 
         self::assertEquals($firstLineItem, $firstMessage->lineItemById(1));
         self::assertEquals($secondLineItem, $firstMessage->lineItemById(2));
+        self::assertNull($firstMessage->lineItemById(3));
     }
 
     private function transactionMessages(string $fileContent): array

--- a/tests/Unit/TransactionMessageTest.php
+++ b/tests/Unit/TransactionMessageTest.php
@@ -279,16 +279,23 @@ EDI;
         $messages = $this->transactionMessages($fileContent);
         $firstMessage = reset($messages);
 
+        $firstLineItem = new LineItem([
+            'LIN' => ['1' => new LINLineItem(['LIN', 1])],
+            'QTY' => ['25' => new QTYQuantity(['QTY', [25, 5]])],
+        ]);
+
+        $secondLineItem = new LineItem([
+            'LIN' => ['2' => new LINLineItem(['LIN', 2])],
+            'QTY' => ['23' => new QTYQuantity(['QTY', [23, 10]])],
+        ]);
+
         self::assertEquals([
-            '1' => new LineItem([
-                'LIN' => ['1' => new LINLineItem(['LIN', 1])],
-                'QTY' => ['25' => new QTYQuantity(['QTY', [25, 5]])],
-            ]),
-            '2' => new LineItem([
-                'LIN' => ['2' => new LINLineItem(['LIN', 2])],
-                'QTY' => ['23' => new QTYQuantity(['QTY', [23, 10]])],
-            ]),
+            '1' => $firstLineItem,
+            '2' => $secondLineItem,
         ], $firstMessage->lineItems());
+
+        self::assertEquals($firstLineItem, $firstMessage->lineItemById(1));
+        self::assertEquals($secondLineItem, $firstMessage->lineItemById(2));
     }
 
     private function transactionMessages(string $fileContent): array


### PR DESCRIPTION
This change introduces the `LineItem` class, which provides more logical access to line item data.

Line items can also be queried by id using `TransactionMessage::lineItemById()`.