### PR TITLE
docs: refresh README and AGENTS.md for devs and agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,20 +46,42 @@ TransactionMessage organizes segments three ways:
 
 **Segment abstraction**:
 - SegmentInterface: `tag()`, `subId()`, `rawValues()`, `parsedSubId()`
-- AbstractSegment: Base implementation (handles subId parsing)
+- AbstractSegment: Base implementation. Shared protected helpers segments delegate to:
+  - `requiredSubId()` — subId from `rawValues[1][0]`, throws `MissingSubId` if absent
+  - `component(int $index, int $group = 1)` — read a composite element, `''` if absent
 - ContextSegment: Decorator with `children()` for hierarchy
-- HasRetrievableSegments: Trait for `segmentsByTag()`, `segmentByTagAndSubId()`
+- HasRetrievableSegments: Trait for `segmentsByTag()`, `segmentByTagAndSubId()`, `query()`
 
 **SubId logic**:
-- From `rawValues()[1]`
-- String `'CN'` or array `['21', 'C62']` → joined as `'21:C62'`
-- Used for distinguishing multiple segments with same tag
+- Base `subId()` reads `rawValues()[1]`; string `'CN'` or array `['21', 'C62']` → joined as `'21:C62'`
+- Segments with a mandatory composite id (UNH/UNB/CNT/DTM/CUX/PRI/QTY/RFF) override
+  `subId()` with `requiredSubId()` — these throw `MissingSubId` on malformed input
+- Used for distinguishing multiple segments with the same tag
+
+## Public API Surface (for extraction/consumption)
+
+- **Typed accessors** on segments: e.g. `NADNameAddress::name()/countryCode()`,
+  `QTYQuantity::quantityAsFloat()`, `PRIPrice::priceAsFloat()`, `DTMDateTimePeriod::asDateTime()`
+- **`SegmentQuery`** (`$message->query()`): fluent `withTag/withTags/withSubId/where/ofType/
+  limit/skip/first/last/get/count/exists/isEmpty/map/each`
+- **`Analysis\MessageAnalyzer`**: counts, `getPartyQualifiers()`, `getCurrencies()`,
+  `calculateTotalAmount()/Quantity()`, `getSummary()`
+- **Fluent builders** (`Segments\Builder\*`): `NADNameAddress::builder()` etc. → `build()`
+- **Qualifier constants** (`Segments\Qualifier\*`): NAD/QTY/PRI/DTM/RFF magic-string maps
 
 ## Extension Points
 
 - Add custom segments: Extend AbstractSegment, register in SegmentFactory
 - Modify context rules: Update ContextStackParser::CONTEXT_TAGS/CHILD_TAGS
 - Custom builders: Implement BuilderInterface for different grouping logic
+
+## Conventions & Constraints
+
+- **Min PHP 8.0** (`composer.json` `platform.php: 8.0`) — enums (8.1) are NOT available;
+  use `final class` + `public const` for constant groups (see `Segments/Qualifier/*`).
+- Public library: preserve method signatures and const values; changes to them are BC breaks.
+- All code passes PHP-CS-Fixer, Psalm, PHPStan (level 5) and Rector; tests required for new behavior.
+- Conventional commits (`ref:` for refactors); land work via a branch + PR.
 
 ## Commands
 
@@ -69,3 +91,8 @@ composer test-functional        # Functional tests
 composer quality                # All checks (CS, Psalm, PHPStan, Rector)
 composer csfix                  # Fix code style
 ```
+
+**Toolchain gotcha:** the pinned Psalm (`^4.30`) only runs on **PHP ≤ 8.3** — run it under
+8.3 if your CLI is newer. On PHP > 8.3, PHP-CS-Fixer needs `PHP_CS_FIXER_IGNORE_ENV=1`.
+PHPStan passing does not guarantee Psalm passes (Psalm is stricter about union returns
+from `rawValues()` accessors) — run both before pushing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Internal
 - Deduplicated segment `subId()` and composite-component accessors into shared
   `AbstractSegment` helpers (`requiredSubId()`, `component()`).
-- Strengthened array type hints across the raw-value chain
-  (`array<int, string|array<int, string>>`) and other public docblocks.
+- Added missing `array`/`list` generics on builders, results and the printer,
+  and typed line-item keys as `int|string`; fixed an invalid `@returns` tag.
 - Removed redundant restatement docblocks; kept EDIFACT domain documentation.
+
+#### Documentation
+- Refreshed README and `AGENTS.md`: corrected the RFF qualifier list, dropped
+  stale "New!" markers, fixed `master` → `main` badges, and documented the local
+  toolchain (Psalm requires PHP ≤ 8.3; PHP-CS-Fixer needs `PHP_CS_FIXER_IGNORE_ENV`
+  on newer PHP).
 
 ## [5.4.1] - 2025-12-07
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 📦 EDIFACT Parser
 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Chemaclass/EdifactParser/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Chemaclass/EdifactParser/?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Chemaclass/EdifactParser/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/Chemaclass/EdifactParser/?branch=main)
 [![Type Coverage](https://shepherd.dev/github/Chemaclass/EdifactParser/coverage.svg)](https://shepherd.dev/github/chemaclass/EdifactParser)
-[![CI](https://github.com/Chemaclass/EdifactParser/workflows/CI/badge.svg?branch=master)](https://github.com/Chemaclass/EdifactParser/actions)
+[![CI](https://github.com/Chemaclass/EdifactParser/workflows/CI/badge.svg?branch=main)](https://github.com/Chemaclass/EdifactParser/actions)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg?style=flat-square)](https://php.net/)
 
 **EDIFACT** stands for _Electronic Data Interchange For Administration, Commerce, and Transport_.
@@ -70,7 +70,7 @@ $personName = $nadSegment->rawValues()[4]; // 'Person Name'
 
 ## 📖 Usage Guide
 
-### Typed Accessor Methods (New! ✨)
+### Typed Accessor Methods
 
 Many segments now provide typed accessor methods for cleaner, self-documenting code:
 
@@ -118,7 +118,7 @@ if ($nadSegment) {
 }
 ```
 
-### Fluent Query API (New! ✨)
+### Fluent Query API
 
 Chain filters and transformations for powerful segment querying:
 
@@ -173,7 +173,7 @@ if ($message->query()->withTag('UNS')->exists()) {
 $nadCount = $message->query()->withTag('NAD')->count();
 ```
 
-### Type-Safe Qualifiers with Constants (New! ✨)
+### Type-Safe Qualifiers with Constants
 
 Use predefined constants for common EDIFACT qualifiers to avoid magic strings and improve IDE autocomplete:
 
@@ -216,10 +216,10 @@ Available qualifier constants:
 - `NADQualifier` - Party roles (BY, SU, CN, CZ, DP, IV, PR, CA, FW, MF, UC, WH)
 - `QTYQualifier` - Quantity types (1, 3, 11, 12, 21, 33, 46, 47, 48, 192)
 - `PRIQualifier` - Price types (AAA, AAB, AAE, AAF, AAG, CAL, CT, DIS, LIS, MIN, RRP)
-- `DTMQualifier` - Date/time types (137, 2, 10, 11, etc.)
-- `RFFQualifier` - Reference types (ON, CR, DQ, PD, etc.)
+- `DTMQualifier` - Date/time types (137, 2, 3, 4, 10, 11, 13, etc.)
+- `RFFQualifier` - Reference types (ON, IV, DQ, CU, SRN, CT, POR, etc.)
 
-### Building Segments with Fluent Builders (New! ✨)
+### Building Segments with Fluent Builders
 
 Create segment objects programmatically with a fluent, type-safe API:
 
@@ -262,7 +262,7 @@ echo $qtySegment->quantityAsFloat(); // 100.0
 echo $priSegment->priceAsFloat();    // 99.99
 ```
 
-### Message Statistics and Analysis (New! ✨)
+### Message Statistics and Analysis
 
 Analyze EDIFACT messages to extract statistics and insights:
 
@@ -510,6 +510,11 @@ composer psalm                          # Static analysis (Psalm)
 composer phpstan                        # Static analysis (PHPStan)
 composer rector                         # Apply refactoring rules
 ```
+
+> **Local toolchain:** the pinned Psalm (`vimeo/psalm ^4.30`) runs on **PHP ≤ 8.3** —
+> run it under 8.3 if your CLI is newer (e.g. `/path/to/php8.3 vendor/bin/psalm`). On
+> PHP > 8.3, PHP-CS-Fixer needs `PHP_CS_FIXER_IGNORE_ENV=1`. CI runs the full gate on
+> the supported versions, so `composer quality` there is authoritative.
 
 ### Code Standards
 


### PR DESCRIPTION
Documentation pass, optimized for developers and coding agents. No code changes.

## README
- Fixed the `RFFQualifier` list (`CR`/`PD` never existed — real codes are `ON, IV, DQ, CU, SRN, CT, POR, ...`).
- Pointed the Scrutinizer/CI badges at `main` (were `master`).
- Dropped the transient "(New! ✨)" markers now that these APIs are established.
- Added a **Local toolchain** note: Psalm (`^4.30`) runs on PHP ≤ 8.3; PHP-CS-Fixer needs `PHP_CS_FIXER_IGNORE_ENV=1` on newer PHP.

## AGENTS.md
- Documented the shared `AbstractSegment` helpers (`requiredSubId()`, `component()`) and which segments throw `MissingSubId`.
- Added a **Public API Surface** map (SegmentQuery, MessageAnalyzer, fluent builders, qualifier constants).
- Added **Conventions & Constraints** (min PHP 8.0 / no enums, BC rules, conventional commits) and the Psalm-vs-PHPStan toolchain gotcha.

## CHANGELOG
- Corrected the 5.4.2 entry: the raw-value chain typing was reverted for Psalm compatibility; the note now reflects the actual type changes plus this docs refresh.

Part of the **5.4.2** release.