### PR TITLE
feat: EDIFACT writer/serializer (render segments back to .edi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.0] - 2026-07-22
+
+#### Added
+- **EDIFACT writer/serializer** (`Serializer\EdifactSerializer`): render any
+  `iterable<SegmentInterface>` back into an EDIFACT string — the inverse of parsing.
+  Pairs with the fluent builders to generate messages. Separators and the release
+  char are configurable via `Serializer\UnaSeparators` and can prepend a `UNA` segment.
+  Round-trips the sample file byte-for-byte through the low-level parser. (#58)
+
 ## [5.4.2] - 2026-07-22
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -262,6 +262,28 @@ echo $qtySegment->quantityAsFloat(); // 100.0
 echo $priSegment->priceAsFloat();    // 99.99
 ```
 
+### Writing / Serializing to EDIFACT
+
+Render segments back into an EDIFACT string — the inverse of parsing. Combine with
+the builders to generate messages, or re-serialize parsed segments:
+
+```php
+use EdifactParser\Serializer\EdifactSerializer;
+use EdifactParser\Serializer\UnaSeparators;
+
+$serializer = new EdifactSerializer();
+
+// Serialize built segments (separators and the release char are handled for you)
+echo $serializer->serializeSegment($nadSegment);
+// NAD+BY+123456++ACME Corporation+123 Main Street+Springfield++12345+US'
+
+// Serialize a whole message, optionally prepending the UNA service-string advice
+$edi = $serializer->serialize([$unh, $bgm, $nadSegment, $unt], includeUna: true);
+
+// Custom delimiters
+$custom = new EdifactSerializer(new UnaSeparators(component: '#', element: '|'));
+```
+
 ### Message Statistics and Analysis
 
 Analyze EDIFACT messages to extract statistics and insights:

--- a/src/Serializer/EdifactSerializer.php
+++ b/src/Serializer/EdifactSerializer.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Serializer;
+
+use EdifactParser\Segments\SegmentInterface;
+
+use function array_map;
+use function implode;
+use function is_array;
+
+/**
+ * Renders segments back into an EDIFACT string, the inverse of parsing.
+ * Separators and the release/escape char follow {@see UnaSeparators}.
+ */
+final class EdifactSerializer
+{
+    private UnaSeparators $una;
+
+    public function __construct(?UnaSeparators $una = null)
+    {
+        $this->una = $una ?? UnaSeparators::default();
+    }
+
+    /**
+     * @param iterable<SegmentInterface> $segments
+     */
+    public function serialize(iterable $segments, bool $includeUna = false): string
+    {
+        $lines = [];
+
+        if ($includeUna) {
+            $lines[] = $this->una->toUnaSegment();
+        }
+
+        foreach ($segments as $segment) {
+            $lines[] = $this->serializeSegment($segment);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function serializeSegment(SegmentInterface $segment): string
+    {
+        $parts = [];
+
+        foreach ($segment->rawValues() as $element) {
+            $parts[] = is_array($element)
+                ? implode($this->una->component(), array_map(fn ($value): string => $this->escape((string) $value), $element))
+                : $this->escape((string) $element);
+        }
+
+        return implode($this->una->element(), $parts) . $this->una->segmentTerminator();
+    }
+
+    private function escape(string $value): string
+    {
+        $release = $this->una->release();
+
+        foreach ($this->una->specialCharacters() as $special) {
+            $value = str_replace($special, $release . $special, $value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Serializer/UnaSeparators.php
+++ b/src/Serializer/UnaSeparators.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Serializer;
+
+/**
+ * The EDIFACT service-string advice (UNA): the delimiters used to serialize
+ * segments. Defaults match the UN/EDIFACT standard (`UNA:+.? '`).
+ */
+final class UnaSeparators
+{
+    public function __construct(
+        private string $component = ':',
+        private string $element = '+',
+        private string $decimal = '.',
+        private string $release = '?',
+        private string $segmentTerminator = "'",
+    ) {
+    }
+
+    public static function default(): self
+    {
+        return new self();
+    }
+
+    public function component(): string
+    {
+        return $this->component;
+    }
+
+    public function element(): string
+    {
+        return $this->element;
+    }
+
+    public function release(): string
+    {
+        return $this->release;
+    }
+
+    public function segmentTerminator(): string
+    {
+        return $this->segmentTerminator;
+    }
+
+    /**
+     * The UNA segment string that declares these separators.
+     */
+    public function toUnaSegment(): string
+    {
+        return 'UNA' . $this->component . $this->element . $this->decimal . $this->release . ' ' . $this->segmentTerminator;
+    }
+
+    /**
+     * Characters that must be prefixed with the release char inside a data value.
+     * The release char comes first so escapes added afterwards are not re-escaped.
+     *
+     * @return list<string>
+     */
+    public function specialCharacters(): array
+    {
+        return [$this->release, $this->component, $this->element, $this->segmentTerminator];
+    }
+}

--- a/tests/Unit/Serializer/EdifactSerializerTest.php
+++ b/tests/Unit/Serializer/EdifactSerializerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit\Serializer;
+
+use EDI\Parser;
+use EdifactParser\SegmentList;
+use EdifactParser\Segments\SegmentFactory;
+use EdifactParser\Segments\UnknownSegment;
+use EdifactParser\Serializer\EdifactSerializer;
+use EdifactParser\Serializer\UnaSeparators;
+use PHPUnit\Framework\TestCase;
+
+final class EdifactSerializerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function serializes_a_segment_with_a_composite_element(): void
+    {
+        $segment = new UnknownSegment(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]);
+
+        self::assertSame(
+            "UNH+1+IFTMIN:S:93A:UN:PN001'",
+            (new EdifactSerializer())->serializeSegment($segment),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function escapes_separators_and_the_release_char_inside_values(): void
+    {
+        // '+46980100' must become '?+46980100'; a literal '?' must double.
+        $segment = new UnknownSegment(['COM', ['+46980100', 'AL']]);
+
+        self::assertSame(
+            "COM+?+46980100:AL'",
+            (new EdifactSerializer())->serializeSegment($segment),
+        );
+
+        self::assertSame(
+            "FTX+a??b:c?'d'",
+            (new EdifactSerializer())->serializeSegment(new UnknownSegment(['FTX', ['a?b', "c'd"]])),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function serialize_joins_segments_and_can_prepend_the_una(): void
+    {
+        $serializer = new EdifactSerializer();
+        $segments = [
+            new UnknownSegment(['UNH', '1', ['ORDERS']]),
+            new UnknownSegment(['BGM', '220']),
+        ];
+
+        self::assertSame("UNH+1+ORDERS'\nBGM+220'", $serializer->serialize($segments));
+        self::assertSame("UNA:+.? '\nUNH+1+ORDERS'\nBGM+220'", $serializer->serialize($segments, includeUna: true));
+    }
+
+    /**
+     * @test
+     */
+    public function honours_custom_separators(): void
+    {
+        $serializer = new EdifactSerializer(new UnaSeparators(component: '#', element: '|', segmentTerminator: '~'));
+
+        self::assertSame(
+            'NAD|CN|a#b~',
+            $serializer->serializeSegment(new UnknownSegment(['NAD', 'CN', ['a', 'b']])),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function round_trips_the_sample_file_through_the_low_level_parser(): void
+    {
+        $original = (new Parser())->loadString((string) file_get_contents(__DIR__ . '/../../../example/edifact-sample.edi'))->get();
+
+        $segments = (new SegmentList(SegmentFactory::withDefaultSegments()))->fromRaw($original);
+        $edi = (new EdifactSerializer())->serialize($segments);
+
+        $reparsed = (new Parser())->loadString($edi)->get();
+
+        self::assertSame($original, $reparsed);
+    }
+}


### PR DESCRIPTION
Implements #58. Adds `Serializer\EdifactSerializer` + `Serializer\UnaSeparators` to render any `iterable<SegmentInterface>` back into an EDIFACT string — the inverse of parsing, pairing with the fluent builders to generate messages.

- Escapes the release char and separators; configurable delimiters; optional `UNA` prefix.
- **Round-trips the sample file byte-for-byte** through the low-level parser (test).
- Additive (new API), targeting 5.5.0.

Closes #58