### PR TITLE
feat: typed MOA monetary-amount segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.5.0] - 2026-07-22
 
 #### Added
+- **Typed `MOA` (monetary amount) segment** (`Segments\MOAMonetaryAmount`), now
+  registered by default with `amountQualifier()`/`amount()`/`amountAsFloat()`/
+  `currencyCode()`. `MessageAnalyzer` uses it (previously `MOA` was an
+  `UnknownSegment` read via raw values). (#62)
 - **EDIFACT writer/serializer** (`Serializer\EdifactSerializer`): render any
   `iterable<SegmentInterface>` back into an EDIFACT string — the inverse of parsing.
   Pairs with the fluent builders to generate messages. Separators and the release

--- a/src/Analysis/MessageAnalyzer.php
+++ b/src/Analysis/MessageAnalyzer.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace EdifactParser\Analysis;
 
 use EdifactParser\Segments\CUXCurrencyDetails;
+use EdifactParser\Segments\MOAMonetaryAmount;
 use EdifactParser\Segments\NADNameAddress;
 use EdifactParser\Segments\QTYQuantity;
+use EdifactParser\Segments\SegmentInterface;
 use EdifactParser\TransactionMessage;
 
 use function count;
@@ -102,17 +104,11 @@ final class MessageAnalyzer
         $query = $this->message->query()->withTag('MOA');
 
         if ($qualifier !== null) {
-            $query = $query->where(static function ($segment) use ($qualifier) {
-                $values = $segment->rawValues()[1] ?? [];
-                return is_array($values) && ($values[0] ?? '') === $qualifier;
-            });
+            $query = $query->where(static fn (SegmentInterface $s) => self::moaQualifier($s) === $qualifier);
         }
 
-        $query->each(static function ($segment) use (&$total): void {
-            $values = $segment->rawValues()[1] ?? [];
-            if (is_array($values)) {
-                $total += (float) ($values[1] ?? 0);
-            }
+        $query->each(static function (SegmentInterface $s) use (&$total): void {
+            $total += self::moaAmount($s);
         });
 
         return $total;
@@ -189,5 +185,27 @@ final class MessageAnalyzer
     public function hasSummarySection(): bool
     {
         return $this->hasSegment('UNS');
+    }
+
+    private static function moaQualifier(SegmentInterface $segment): string
+    {
+        if ($segment instanceof MOAMonetaryAmount) {
+            return $segment->amountQualifier();
+        }
+
+        $values = $segment->rawValues()[1] ?? [];
+
+        return is_array($values) ? (string) ($values[0] ?? '') : '';
+    }
+
+    private static function moaAmount(SegmentInterface $segment): float
+    {
+        if ($segment instanceof MOAMonetaryAmount) {
+            return $segment->amountAsFloat();
+        }
+
+        $values = $segment->rawValues()[1] ?? [];
+
+        return is_array($values) ? (float) ($values[1] ?? 0) : 0.0;
     }
 }

--- a/src/Segments/MOAMonetaryAmount.php
+++ b/src/Segments/MOAMonetaryAmount.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class MOAMonetaryAmount extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'MOA';
+    }
+
+    public function subId(): string
+    {
+        return $this->requiredSubId();
+    }
+
+    /**
+     * Monetary amount type qualifier (e.g., '79' = Total line items amount,
+     * '125' = Taxable amount, '86' = Message total monetary amount)
+     */
+    public function amountQualifier(): string
+    {
+        return $this->component(0);
+    }
+
+    /**
+     * Monetary amount (raw string)
+     */
+    public function amount(): string
+    {
+        return $this->component(1);
+    }
+
+    public function amountAsFloat(): float
+    {
+        return (float) $this->amount();
+    }
+
+    /**
+     * Currency code (ISO 4217), when present in the composite
+     */
+    public function currencyCode(): string
+    {
+        return $this->component(2);
+    }
+}

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -33,6 +33,7 @@ final class SegmentFactory implements SegmentFactoryInterface
         'PRI' => PRIPrice::class,
         'PIA' => PIAAdditionalProductId::class,
         'UNS' => UNSSectionControl::class,
+        'MOA' => MOAMonetaryAmount::class,
     ];
 
     private const TAG_LENGTH = 3;

--- a/tests/Unit/Segments/MOAMonetaryAmountTest.php
+++ b/tests/Unit/Segments/MOAMonetaryAmountTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit\Segments;
+
+use EdifactParser\Segments\MOAMonetaryAmount;
+use EdifactParser\Segments\SegmentFactory;
+use PHPUnit\Framework\TestCase;
+
+final class MOAMonetaryAmountTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function typed_accessors(): void
+    {
+        $segment = new MOAMonetaryAmount(['MOA', ['79', '1250.50', 'EUR']]);
+
+        self::assertSame('MOA', $segment->tag());
+        self::assertSame('79', $segment->subId());
+        self::assertSame('79', $segment->amountQualifier());
+        self::assertSame('1250.50', $segment->amount());
+        self::assertSame(1250.50, $segment->amountAsFloat());
+        self::assertSame('EUR', $segment->currencyCode());
+    }
+
+    /**
+     * @test
+     */
+    public function factory_creates_a_typed_moa_segment_by_default(): void
+    {
+        $segment = SegmentFactory::withDefaultSegments()
+            ->createSegmentFromArray(['MOA', ['79', '1250.50']]);
+
+        self::assertInstanceOf(MOAMonetaryAmount::class, $segment);
+    }
+}


### PR DESCRIPTION
Part of #62. Adds `Segments\MOAMonetaryAmount` (typed `amountQualifier()/amount()/amountAsFloat()/currencyCode()`), registered by default — fixing the phantom `MOA` tag that `MessageAnalyzer` already counted but which parsed as `UnknownSegment`.

`MessageAnalyzer::calculateTotalAmount()` now uses the typed segment (raw fallback kept for custom factories). Additive, 5.5.0.

The remaining #62 item — injectable grouping rules — restructures the static grouping pipeline, so it's folded into the 6.0 envelope work (#59) where that BC change is in scope.

Refs #62