### PR TITLE
feat: functional groups (UNG/UNE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.5.0] - 2026-07-22
 
 #### Added
+- **Functional groups (UNG/UNE)**: typed `UNGFunctionalGroupHeader` /
+  `UNEFunctionalGroupTrailer` segments and `ParserResult::functionalGroups()`
+  returning `FunctionalGroup` objects (header, trailer, messages). Interchanges
+  without groups are unaffected — messages stay available flat via
+  `transactionMessages()`. (#59)
 - **Typed `MOA` (monetary amount) segment** (`Segments\MOAMonetaryAmount`), now
   registered by default with `amountQualifier()`/`amount()`/`amountAsFloat()`/
   `currencyCode()`. `MessageAnalyzer` uses it (previously `MOA` was an

--- a/README.md
+++ b/README.md
@@ -387,6 +387,24 @@ foreach ($result->transactionMessages() as $message) {
 }
 ```
 
+### Functional Groups (UNG/UNE)
+
+When an interchange wraps messages in `UNG...UNE` functional groups, access them
+directly. Interchanges without groups return an empty list — messages remain
+available flat via `transactionMessages()`:
+
+```php
+foreach ($result->functionalGroups() as $group) {
+    $group->messageType();              // e.g. 'ORDERS' (from the UNG)
+    $group->header()->groupReference(); // functional group reference number
+    $group->trailer()?->controlCount(); // message count from the UNE
+
+    foreach ($group->messages() as $message) {
+        // Process each message in this group...
+    }
+}
+```
+
 ---
 
 ## 🔧 Extending with Custom Segments

--- a/src/FunctionalGroup.php
+++ b/src/FunctionalGroup.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser;
+
+use EdifactParser\Segments\UNEFunctionalGroupTrailer;
+use EdifactParser\Segments\UNGFunctionalGroupHeader;
+
+/**
+ * A UNG...UNE functional group: a set of messages of the same type wrapped by a
+ * UNG header and UNE trailer. Optional in EDIFACT — many interchanges send
+ * messages directly under the interchange (UNB) with no functional group.
+ */
+final class FunctionalGroup
+{
+    /**
+     * @param list<TransactionMessage> $messages
+     */
+    public function __construct(
+        private UNGFunctionalGroupHeader $header,
+        private array $messages,
+        private ?UNEFunctionalGroupTrailer $trailer = null,
+    ) {
+    }
+
+    public function header(): UNGFunctionalGroupHeader
+    {
+        return $this->header;
+    }
+
+    public function trailer(): ?UNEFunctionalGroupTrailer
+    {
+        return $this->trailer;
+    }
+
+    public function messageType(): string
+    {
+        return $this->header->messageType();
+    }
+
+    /**
+     * @return list<TransactionMessage>
+     */
+    public function messages(): array
+    {
+        return $this->messages;
+    }
+}

--- a/src/ParserResult.php
+++ b/src/ParserResult.php
@@ -12,10 +12,12 @@ final class ParserResult
 
     /**
      * @param list<TransactionMessage> $transactionMessages
+     * @param list<FunctionalGroup> $functionalGroups
      */
     public function __construct(
         private TransactionMessage $globalSegments,
         private array $transactionMessages,
+        private array $functionalGroups = [],
     ) {
     }
 
@@ -30,6 +32,17 @@ final class ParserResult
     public function transactionMessages(): array
     {
         return $this->transactionMessages;
+    }
+
+    /**
+     * UNG...UNE functional groups, when the interchange uses them (otherwise empty;
+     * messages are still available flat via transactionMessages()).
+     *
+     * @return list<FunctionalGroup>
+     */
+    public function functionalGroups(): array
+    {
+        return $this->functionalGroups;
     }
 
     /**

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -34,6 +34,8 @@ final class SegmentFactory implements SegmentFactoryInterface
         'PIA' => PIAAdditionalProductId::class,
         'UNS' => UNSSectionControl::class,
         'MOA' => MOAMonetaryAmount::class,
+        'UNG' => UNGFunctionalGroupHeader::class,
+        'UNE' => UNEFunctionalGroupTrailer::class,
     ];
 
     private const TAG_LENGTH = 3;

--- a/src/Segments/UNEFunctionalGroupTrailer.php
+++ b/src/Segments/UNEFunctionalGroupTrailer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+use function is_array;
+
+/** @psalm-immutable */
+final class UNEFunctionalGroupTrailer extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'UNE';
+    }
+
+    /**
+     * Number of messages in the functional group
+     */
+    public function controlCount(): string
+    {
+        $value = $this->rawValues()[1] ?? '';
+
+        return is_array($value) ? '' : (string) $value;
+    }
+
+    /**
+     * Functional group reference number (must match the UNG)
+     */
+    public function groupReference(): string
+    {
+        $value = $this->rawValues()[2] ?? '';
+
+        return is_array($value) ? '' : (string) $value;
+    }
+}

--- a/src/Segments/UNGFunctionalGroupHeader.php
+++ b/src/Segments/UNGFunctionalGroupHeader.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+use function is_array;
+
+/** @psalm-immutable */
+final class UNGFunctionalGroupHeader extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'UNG';
+    }
+
+    /**
+     * Message type grouped by this functional group (e.g., 'ORDERS', 'INVOIC')
+     */
+    public function messageType(): string
+    {
+        $value = $this->rawValues()[1] ?? '';
+
+        return is_array($value) ? '' : (string) $value;
+    }
+
+    /**
+     * Functional group reference number
+     */
+    public function groupReference(): string
+    {
+        $value = $this->rawValues()[5] ?? '';
+
+        return is_array($value) ? '' : (string) $value;
+    }
+}

--- a/src/TransactionMessage.php
+++ b/src/TransactionMessage.php
@@ -7,6 +7,8 @@ namespace EdifactParser;
 use Countable;
 use EdifactParser\MessageDataBuilder\Builder as MessageDataBuilder;
 use EdifactParser\Segments\SegmentInterface;
+use EdifactParser\Segments\UNEFunctionalGroupTrailer;
+use EdifactParser\Segments\UNGFunctionalGroupHeader;
 use EdifactParser\Segments\UNHMessageHeader;
 use EdifactParser\Segments\UNTMessageFooter;
 
@@ -38,7 +40,26 @@ final class TransactionMessage implements Countable
         $messages = [];
         $groupedSegments = [];
 
+        $functionalGroups = [];
+        $openHeader = null;
+        $openGroupMessages = [];
+
         foreach ($segments as $segment) {
+            if ($segment instanceof UNGFunctionalGroupHeader) {
+                $openHeader = $segment;
+                $openGroupMessages = [];
+                continue;
+            }
+
+            if ($segment instanceof UNEFunctionalGroupTrailer) {
+                if ($openHeader !== null) {
+                    $functionalGroups[] = new FunctionalGroup($openHeader, $openGroupMessages, $segment);
+                    $openHeader = null;
+                    $openGroupMessages = [];
+                }
+                continue;
+            }
+
             if ($segment instanceof UNHMessageHeader) {
                 $groupedSegments = [];
             }
@@ -46,13 +67,19 @@ final class TransactionMessage implements Countable
             $groupedSegments[] = $segment;
 
             if ($segment instanceof UNTMessageFooter) {
-                $messages[] = self::groupSegmentsByName(...$groupedSegments);
+                $message = self::groupSegmentsByName(...$groupedSegments);
+                $messages[] = $message;
+
+                if ($openHeader !== null) {
+                    $openGroupMessages[] = $message;
+                }
             }
         }
 
         return new ParserResult(
             self::filterGlobalSegments($segments),
-            self::hasUnhSegment(...$messages)
+            self::hasUnhSegment(...$messages),
+            $functionalGroups,
         );
     }
 

--- a/tests/Unit/FunctionalGroupTest.php
+++ b/tests/Unit/FunctionalGroupTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit;
+
+use EdifactParser\EdifactParser;
+use PHPUnit\Framework\TestCase;
+
+final class FunctionalGroupTest extends TestCase
+{
+    private const WITH_GROUPS = <<<'EDI'
+        UNB+UNOC:3+SENDER+RECIPIENT+20191011:1200+REF'
+        UNG+ORDERS+S1+R1+20191011:1200+1+UN+D:96A'
+        UNH+1+ORDERS:D:96A:UN'
+        BGM+220'
+        UNT+3+1'
+        UNH+2+ORDERS:D:96A:UN'
+        BGM+221'
+        UNT+3+2'
+        UNE+2+1'
+        UNG+INVOIC+S1+R1+20191011:1200+2+UN+D:96A'
+        UNH+3+INVOIC:D:96A:UN'
+        BGM+380'
+        UNT+3+3'
+        UNE+1+2'
+        UNZ+3+REF'
+        EDI;
+
+    /**
+     * @test
+     */
+    public function exposes_functional_groups_while_keeping_messages_flat(): void
+    {
+        $result = EdifactParser::createWithDefaultSegments()->parse(self::WITH_GROUPS);
+
+        // Flat view is preserved (backward compatible)
+        self::assertCount(3, $result->transactionMessages());
+
+        $groups = $result->functionalGroups();
+        self::assertCount(2, $groups);
+
+        self::assertSame('ORDERS', $groups[0]->messageType());
+        self::assertSame('1', $groups[0]->header()->groupReference());
+        self::assertCount(2, $groups[0]->messages());
+        self::assertSame('2', $groups[0]->trailer()?->controlCount());
+
+        self::assertSame('INVOIC', $groups[1]->messageType());
+        self::assertCount(1, $groups[1]->messages());
+    }
+
+    /**
+     * @test
+     */
+    public function interchange_without_groups_has_no_functional_groups(): void
+    {
+        $result = EdifactParser::createWithDefaultSegments()
+            ->parseFile(__DIR__ . '/../../example/edifact-sample.edi');
+
+        self::assertSame([], $result->functionalGroups());
+        self::assertNotEmpty($result->transactionMessages());
+    }
+}


### PR DESCRIPTION
Part of #59. Adds typed `UNGFunctionalGroupHeader`/`UNEFunctionalGroupTrailer` and `ParserResult::functionalGroups()` → `FunctionalGroup` (header, trailer, messages).

- Additive: interchanges without UNG/UNE return an empty list; `transactionMessages()` still returns all messages flat (backward compatible).
- Tested with a two-group interchange and the no-group sample.

The remaining #59 item — duplicate-segment preservation — is a larger, BC-breaking change (result-shape) and stays the 6.0 work.

Refs #59