### PR TITLE
feat: structural validation / conformance checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.5.0] - 2026-07-22
 
 #### Added
+- **Structural validation** (`Validation\MessageValidator` + `MessageRuleSet`):
+  check a message against a pluggable rule set (required segments and per-tag
+  cardinality) and get a list of `ValidationViolation`s back — never throws;
+  empty means conforming. (#60)
 - **Functional groups (UNG/UNE)**: typed `UNGFunctionalGroupHeader` /
   `UNEFunctionalGroupTrailer` segments and `ParserResult::functionalGroups()`
   returning `FunctionalGroup` objects (header, trailer, messages). Interchanges

--- a/README.md
+++ b/README.md
@@ -407,6 +407,33 @@ foreach ($result->functionalGroups() as $group) {
 
 ---
 
+### Validation / Conformance
+
+Check a message against a pluggable rule set (required segments + cardinality). The
+validator never throws — an empty list means the message conforms:
+
+```php
+use EdifactParser\Validation\MessageRuleSet;
+use EdifactParser\Validation\MessageValidator;
+
+$rules = MessageRuleSet::forType('ORDERS')
+    ->require('UNH', 'BGM', 'UNT')  // mandatory segments
+    ->occurs('NAD', 1, 5)           // between 1 and 5 NAD segments
+    ->occurs('LIN', 1);             // at least 1 line item
+
+$validator = new MessageValidator();
+
+foreach ($validator->validate($message, $rules) as $violation) {
+    echo "{$violation->segmentTag()}: {$violation->message()}\n";
+}
+
+if ($validator->isValid($message, $rules)) {
+    // conforms to the rule set
+}
+```
+
+---
+
 ## 🔧 Extending with Custom Segments
 
 ### Step 1: Create Your Segment Class

--- a/src/Validation/MessageRuleSet.php
+++ b/src/Validation/MessageRuleSet.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Validation;
+
+/**
+ * A conformance rule set for one message type: which segment tags are required
+ * and, optionally, how many times each tag may occur.
+ *
+ * Rule sets are plain data — build your own per message type, or extend the
+ * fluent helpers below.
+ */
+final class MessageRuleSet
+{
+    /**
+     * @param list<string> $requiredTags
+     * @param array<string, array{min: int, max: int|null}> $cardinality
+     */
+    public function __construct(
+        private string $messageType,
+        private array $requiredTags = [],
+        private array $cardinality = [],
+    ) {
+    }
+
+    public static function forType(string $messageType): self
+    {
+        return new self($messageType);
+    }
+
+    public function require(string ...$tags): self
+    {
+        $clone = clone $this;
+        $clone->requiredTags = [...$this->requiredTags, ...array_values($tags)];
+
+        return $clone;
+    }
+
+    public function occurs(string $tag, int $min, ?int $max = null): self
+    {
+        $clone = clone $this;
+        $clone->cardinality[$tag] = ['min' => $min, 'max' => $max];
+
+        return $clone;
+    }
+
+    public function messageType(): string
+    {
+        return $this->messageType;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function requiredTags(): array
+    {
+        return $this->requiredTags;
+    }
+
+    /**
+     * @return array<string, array{min: int, max: int|null}>
+     */
+    public function cardinality(): array
+    {
+        return $this->cardinality;
+    }
+}

--- a/src/Validation/MessageValidator.php
+++ b/src/Validation/MessageValidator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Validation;
+
+use EdifactParser\TransactionMessage;
+
+/**
+ * Checks a {@see TransactionMessage} against a {@see MessageRuleSet} and returns
+ * the violations found. It never throws — an empty list means the message conforms.
+ */
+final class MessageValidator
+{
+    /**
+     * @return list<ValidationViolation>
+     */
+    public function validate(TransactionMessage $message, MessageRuleSet $rules): array
+    {
+        $violations = [];
+
+        foreach ($rules->requiredTags() as $tag) {
+            if ($message->query()->withTag($tag)->count() === 0) {
+                $violations[] = new ValidationViolation($tag, 'required', "Missing required segment '{$tag}'");
+            }
+        }
+
+        foreach ($rules->cardinality() as $tag => $bounds) {
+            $count = $message->query()->withTag($tag)->count();
+
+            if ($count < $bounds['min']) {
+                $violations[] = new ValidationViolation(
+                    $tag,
+                    'cardinality',
+                    "Segment '{$tag}' occurs {$count} time(s), expected at least {$bounds['min']}",
+                );
+            }
+
+            if ($bounds['max'] !== null && $count > $bounds['max']) {
+                $violations[] = new ValidationViolation(
+                    $tag,
+                    'cardinality',
+                    "Segment '{$tag}' occurs {$count} time(s), expected at most {$bounds['max']}",
+                );
+            }
+        }
+
+        return $violations;
+    }
+
+    public function isValid(TransactionMessage $message, MessageRuleSet $rules): bool
+    {
+        return $this->validate($message, $rules) === [];
+    }
+}

--- a/src/Validation/ValidationViolation.php
+++ b/src/Validation/ValidationViolation.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Validation;
+
+/**
+ * A single conformance problem found by {@see MessageValidator}: which segment tag,
+ * which rule was broken, and a human-readable description.
+ */
+final class ValidationViolation
+{
+    public function __construct(
+        private string $segmentTag,
+        private string $rule,
+        private string $message,
+    ) {
+    }
+
+    public function segmentTag(): string
+    {
+        return $this->segmentTag;
+    }
+
+    public function rule(): string
+    {
+        return $this->rule;
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+}

--- a/tests/Unit/Validation/MessageValidatorTest.php
+++ b/tests/Unit/Validation/MessageValidatorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit\Validation;
+
+use EdifactParser\EdifactParser;
+use EdifactParser\TransactionMessage;
+use EdifactParser\Validation\MessageRuleSet;
+use EdifactParser\Validation\MessageValidator;
+use PHPUnit\Framework\TestCase;
+
+final class MessageValidatorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function a_conforming_message_yields_no_violations(): void
+    {
+        $rules = MessageRuleSet::forType('IFTMIN')->require('UNH', 'BGM', 'UNT');
+
+        $validator = new MessageValidator();
+        self::assertSame([], $validator->validate($this->sampleMessage(), $rules));
+        self::assertTrue($validator->isValid($this->sampleMessage(), $rules));
+    }
+
+    /**
+     * @test
+     */
+    public function reports_a_missing_required_segment(): void
+    {
+        $rules = MessageRuleSet::forType('IFTMIN')->require('MOA');
+
+        $violations = (new MessageValidator())->validate($this->sampleMessage(), $rules);
+
+        self::assertCount(1, $violations);
+        self::assertSame('MOA', $violations[0]->segmentTag());
+        self::assertSame('required', $violations[0]->rule());
+    }
+
+    /**
+     * @test
+     */
+    public function reports_cardinality_violations(): void
+    {
+        // The sample message has 2 NAD segments (CZ and CN) and 1 BGM.
+        $rules = MessageRuleSet::forType('IFTMIN')
+            ->occurs('NAD', 1, 1)   // too many (2 > 1)
+            ->occurs('BGM', 2);     // too few  (1 < 2)
+
+        $violations = (new MessageValidator())->validate($this->sampleMessage(), $rules);
+
+        self::assertCount(2, $violations);
+        self::assertSame('cardinality', $violations[0]->rule());
+        self::assertSame('cardinality', $violations[1]->rule());
+    }
+    private function sampleMessage(): TransactionMessage
+    {
+        return EdifactParser::createWithDefaultSegments()
+            ->parseFile(__DIR__ . '/../../../example/edifact-sample.edi')
+            ->transactionMessages()[0];
+    }
+}


### PR DESCRIPTION
Implements the core of #60. Adds `Validation\MessageValidator`, `MessageRuleSet` (fluent `require()`/`occurs()`) and `ValidationViolation`.

- Checks **required segments** and **per-tag cardinality** (min/max) against a pluggable rule set.
- Returns structured violations; **never throws** (empty = conforming).
- Additive, 5.5.0.

Sequence/segment-group ordering is a natural follow-up (needs EDIFACT segment-group modeling) and can extend `MessageRuleSet`.

Refs #60