### PR TITLE
feat: streaming parser for large interchanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.5.0] - 2026-07-22
 
 #### Added
+- **Streaming parser** (`StreamingParser`): parse large interchanges incrementally,
+  yielding one `TransactionMessage` at a time in bounded memory (only a single
+  message is buffered), instead of building the whole result up front. (#61)
 - **Structural validation** (`Validation\MessageValidator` + `MessageRuleSet`):
   check a message against a pluggable rule set (required segments and per-tag
   cardinality) and get a list of `ValidationViolation`s back — never throws;

--- a/README.md
+++ b/README.md
@@ -375,6 +375,20 @@ foreach ($message->contextSegments() as $context) {
 }
 ```
 
+### Streaming Large Files
+
+For large interchanges, stream messages one at a time in bounded memory instead of
+building the whole result up front:
+
+```php
+use EdifactParser\StreamingParser;
+
+foreach (StreamingParser::createWithDefaultSegments()->parseFile('/path/to/large.edi') as $message) {
+    // Only one message is held in memory at a time
+    process($message);
+}
+```
+
 ### Global vs Transaction Segments
 
 ```php

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser;
+
+use EdifactParser\Exception\InvalidFile;
+
+use function fclose;
+use function feof;
+use function fopen;
+use function fread;
+use function implode;
+use function strlen;
+use function strtoupper;
+use function substr;
+use function trim;
+
+/**
+ * Parses an EDIFACT file incrementally, yielding one {@see TransactionMessage} at a
+ * time. Only a single message is held in memory at once, so arbitrarily large
+ * interchanges parse in bounded memory — unlike {@see EdifactParser} which builds
+ * the whole result up front.
+ *
+ * Assumes the default segment terminator (`'`) and release char (`?`).
+ */
+final class StreamingParser
+{
+    private const CHUNK_BYTES = 8192;
+
+    public function __construct(
+        private EdifactParser $parser,
+        private string $segmentTerminator = "'",
+        private string $releaseCharacter = '?',
+    ) {
+    }
+
+    public static function createWithDefaultSegments(): self
+    {
+        return new self(EdifactParser::createWithDefaultSegments());
+    }
+
+    /**
+     * @return iterable<TransactionMessage>
+     */
+    public function parseFile(string $filePath): iterable
+    {
+        $handle = @fopen($filePath, 'rb');
+
+        if ($handle === false) {
+            throw InvalidFile::withErrors(["Unable to read file: {$filePath}"]);
+        }
+
+        try {
+            yield from $this->streamMessages($handle);
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @param resource $handle
+     *
+     * @return iterable<TransactionMessage>
+     */
+    private function streamMessages($handle): iterable
+    {
+        $buffer = '';
+        $message = [];
+        $inMessage = false;
+
+        while (!feof($handle)) {
+            $chunk = fread($handle, self::CHUNK_BYTES);
+            if ($chunk === false) {
+                break;
+            }
+
+            $buffer .= $chunk;
+
+            foreach ($this->extractSegments($buffer) as $segment) {
+                $tag = strtoupper(substr($segment, 0, 3));
+
+                if ($tag === 'UNH') {
+                    $message = [$segment];
+                    $inMessage = true;
+                    continue;
+                }
+
+                if ($inMessage) {
+                    $message[] = $segment;
+                }
+
+                if ($tag === 'UNT') {
+                    $text = implode($this->segmentTerminator, $message) . $this->segmentTerminator;
+                    yield from $this->parser->parse($text)->transactionMessages();
+
+                    $message = [];
+                    $inMessage = false;
+                }
+            }
+        }
+    }
+
+    /**
+     * Splits complete segments out of the buffer, leaving the trailing partial
+     * segment (and its escape state) in place for the next read.
+     *
+     * @return list<string>
+     */
+    private function extractSegments(string &$buffer): array
+    {
+        $segments = [];
+        $current = '';
+        $escaped = false;
+        $length = strlen($buffer);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $buffer[$i];
+
+            if ($escaped) {
+                $current .= $char;
+                $escaped = false;
+                continue;
+            }
+
+            if ($char === $this->releaseCharacter) {
+                $current .= $char;
+                $escaped = true;
+                continue;
+            }
+
+            if ($char === $this->segmentTerminator) {
+                $trimmed = trim($current);
+                if ($trimmed !== '') {
+                    $segments[] = $trimmed;
+                }
+                $current = '';
+                continue;
+            }
+
+            $current .= $char;
+        }
+
+        $buffer = $current;
+
+        return $segments;
+    }
+}

--- a/tests/Unit/StreamingParserTest.php
+++ b/tests/Unit/StreamingParserTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit;
+
+use EdifactParser\EdifactParser;
+use EdifactParser\Exception\InvalidFile;
+use EdifactParser\StreamingParser;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+
+final class StreamingParserTest extends TestCase
+{
+    private const SAMPLE = __DIR__ . '/../../example/edifact-sample.edi';
+
+    /**
+     * @test
+     */
+    public function streams_the_same_messages_as_the_batch_parser(): void
+    {
+        $batch = EdifactParser::createWithDefaultSegments()->parseFile(self::SAMPLE)->transactionMessages();
+
+        $streamed = [];
+        foreach (StreamingParser::createWithDefaultSegments()->parseFile(self::SAMPLE) as $message) {
+            $streamed[] = $message;
+        }
+
+        self::assertCount(count($batch), $streamed);
+        self::assertEquals($batch[0]->allSegments(), $streamed[0]->allSegments());
+        self::assertEquals($batch[1]->allSegments(), $streamed[1]->allSegments());
+    }
+
+    /**
+     * @test
+     */
+    public function parsing_is_lazy_and_defers_io_until_iterated(): void
+    {
+        // Building the stream must not open the file yet (the generator body,
+        // including fopen, runs only on the first iteration).
+        $stream = StreamingParser::createWithDefaultSegments()->parseFile('/no/such/edifact/file.edi');
+
+        $this->expectException(InvalidFile::class);
+        foreach ($stream as $message) {
+            // unreachable — the missing file throws as soon as iteration starts
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function streams_a_large_interchange_message_by_message(): void
+    {
+        $oneMessage = "UNH+1+ORDERS:D:96A:UN'BGM+220'DTM+10:20191011:102'UNT+3+1'";
+        $path = (string) tempnam(sys_get_temp_dir(), 'edi');
+        file_put_contents($path, "UNB+UNOC:3+S+R+20191011:1200+REF'" . str_repeat($oneMessage, 5000) . "UNZ+5000+REF'");
+
+        try {
+            $count = 0;
+            foreach (StreamingParser::createWithDefaultSegments()->parseFile($path) as $message) {
+                ++$count;
+            }
+            self::assertSame(5000, $count);
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
Implements #61. Adds `StreamingParser` — parse a file incrementally, yielding one `TransactionMessage` at a time in **bounded memory** (only one message buffered).

- Splits on the unescaped segment terminator (release-char aware) and reuses the tested batch parse path per message.
- Generator-based: IO is deferred until iteration.
- Verified: streams 5000 messages at ~8 MB, and output matches the batch parser message-for-message.

Closes #61