### PR TITLE
feat!: injectable grouping rules + duplicate preservation + sequence validation (6.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,11 @@ TransactionMessage organizes segments three ways:
 
 ## Key Patterns
 
-**Context hierarchy** (`ContextStackParser`):
+**Context hierarchy** (`ContextStackParser`, defaults — override via `GroupingRules`):
 - Parents: NAD, LIN, DOC
 - Children: COM, CTA, PIA, IMD, MEA, QTY, PRI, TAX, DTM, MOA
 
-**Line item boundaries** (`MessageDataBuilder\Builder`):
+**Line item boundaries** (`MessageDataBuilder\Builder`, defaults — override via `GroupingRules`):
 - Start: LIN segment
 - End: UNS, CNT, or UNT segments
 - DetailsSectionBuilder groups segments into line items
@@ -71,7 +71,10 @@ TransactionMessage organizes segments three ways:
 - **Writer** (`Serializer\EdifactSerializer` + `UnaSeparators`): render `iterable<SegmentInterface>`
   back to an `.edi` string (inverse of parsing)
 - **Validation** (`Validation\MessageValidator` + `MessageRuleSet` → `ValidationViolation`):
-  required-segment and cardinality conformance checks; never throws
+  required-segment, cardinality and `inSequence()` conformance checks; never throws
+- **Duplicate-preserving access**: `query()` and `TransactionMessage::segments()` keep
+  every segment in order (dups included); keyed views index by tag+subId (last wins)
+- **Grouping config** (`GroupingRules`): injectable context/child/line-item-break tags
 - **Streaming** (`StreamingParser`): generator yielding one `TransactionMessage` at a time,
   bounded memory for large interchanges
 - **Functional groups** (`ParserResult::functionalGroups()` → `FunctionalGroup`): UNG/UNE
@@ -80,7 +83,8 @@ TransactionMessage organizes segments three ways:
 ## Extension Points
 
 - Add custom segments: Extend AbstractSegment, register in SegmentFactory
-- Modify context rules: Update ContextStackParser::CONTEXT_TAGS/CHILD_TAGS
+- Modify context / line-item rules: pass a customized `GroupingRules` to the
+  `EdifactParser` constructor (no longer hardcoded consts)
 - Custom builders: Implement BuilderInterface for different grouping logic
 
 ## Conventions & Constraints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2026-07-22
+
+#### Added
+- **Duplicate-segment preservation**: `TransactionMessage::query()` and the new
+  `TransactionMessage::segments()` now return every segment in original order,
+  including repeated segments that share a tag + subId (previously collapsed by the
+  keyed index). `count()` now reports the true segment total. (#59)
+- **Injectable grouping rules** (`GroupingRules`): customize context parents/children
+  and the tags that close a line-item section, passed via a new optional second
+  argument to the `EdifactParser` constructor. (#62)
+- **Sequence validation**: `MessageRuleSet::inSequence(...$tags)` checks the relative
+  order of segments; `MessageValidator` reports a `sequence` violation when broken. (#60)
+
+#### Changed (breaking)
+- `EdifactParser::__construct()` takes an optional `?GroupingRules $groupingRules`
+  second argument. Existing single-argument calls keep working.
+- `TransactionMessage::groupSegmentsByMessage()` now takes a `GroupingRules` as its
+  first argument (before the variadic segments).
+- `TransactionMessage::__construct()` gained a fourth `array $segments` argument (the
+  ordered, duplicate-preserving segment list). Optional; defaults to `[]`.
+- `TransactionMessage::count()` now returns the total number of segments, not the
+  number of distinct tags.
+- `TransactionMessage::query()` now preserves duplicates and original order.
+
+##### Migration
+- Building a parser: `new EdifactParser($factory)` is unchanged; pass
+  `new EdifactParser($factory, $groupingRules)` only to customize grouping.
+- Calling `TransactionMessage::groupSegmentsByMessage(...$segments)` directly:
+  pass rules first — `groupSegmentsByMessage(GroupingRules::default(), ...$segments)`.
+- If you relied on `count($message)` returning the distinct-tag count, use
+  `count($message->allSegments())` instead.
+
 ## [5.5.0] - 2026-07-22
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ if ($message->query()->withTag('UNS')->exists()) {
 $nadCount = $message->query()->withTag('NAD')->count();
 ```
 
+> `query()` and `$message->segments()` preserve **every** segment in original order,
+> including duplicates that share a tag + subId. The keyed lookups
+> (`segmentByTagAndSubId()`, `allSegments()`) index by tag + subId and keep the last
+> occurrence — use the query API when duplicates matter.
+
 ### Type-Safe Qualifiers with Constants
 
 Use predefined constants for common EDIFACT qualifiers to avoid magic strings and improve IDE autocomplete:
@@ -431,9 +436,10 @@ use EdifactParser\Validation\MessageRuleSet;
 use EdifactParser\Validation\MessageValidator;
 
 $rules = MessageRuleSet::forType('ORDERS')
-    ->require('UNH', 'BGM', 'UNT')  // mandatory segments
-    ->occurs('NAD', 1, 5)           // between 1 and 5 NAD segments
-    ->occurs('LIN', 1);             // at least 1 line item
+    ->require('UNH', 'BGM', 'UNT')       // mandatory segments
+    ->occurs('NAD', 1, 5)                // between 1 and 5 NAD segments
+    ->occurs('LIN', 1)                   // at least 1 line item
+    ->inSequence('UNH', 'BGM', 'UNT');   // relative order of these tags
 
 $validator = new MessageValidator();
 
@@ -512,6 +518,25 @@ final class LOCLocationTest extends TestCase
         self::assertEquals('DEHAM', $segment->locationCode());
     }
 }
+```
+
+### Custom Grouping Rules
+
+Context hierarchies and line-item boundaries are driven by `GroupingRules`. Pass a
+customized instance to the parser to change which tags open a context, attach as
+children, or close a line-item section:
+
+```php
+use EdifactParser\EdifactParser;
+use EdifactParser\GroupingRules;
+use EdifactParser\Segments\SegmentFactory;
+
+$rules = GroupingRules::default()
+    ->withContextTags(['NAD', 'LIN'])           // parents that open a context
+    ->withChildTags(['CTA', 'COM', 'DTM'])       // segments attached to the context
+    ->withBreakLineItemTags(['UNS', 'CNT', 'UNT']); // tags that end the detail section
+
+$parser = new EdifactParser(SegmentFactory::withDefaultSegments(), $rules);
 ```
 
 ---

--- a/src/ContextStackParser.php
+++ b/src/ContextStackParser.php
@@ -6,26 +6,14 @@ namespace EdifactParser;
 
 use EdifactParser\Segments\SegmentInterface;
 
-use function array_key_exists;
-
 final class ContextStackParser
 {
-    /** @var array<string, bool> */
-    private const CONTEXT_TAGS = ['NAD' => true, 'LIN' => true, 'DOC' => true];
+    private GroupingRules $rules;
 
-    /** @var array<string, bool> */
-    private const CHILD_TAGS = [
-        'COM' => true,
-        'CTA' => true,
-        'PIA' => true,
-        'IMD' => true,
-        'MEA' => true,
-        'QTY' => true,
-        'PRI' => true,
-        'TAX' => true,
-        'DTM' => true,
-        'MOA' => true,
-    ];
+    public function __construct(?GroupingRules $rules = null)
+    {
+        $this->rules = $rules ?? GroupingRules::default();
+    }
 
     /**
      * @return list<ContextSegment>
@@ -38,7 +26,7 @@ final class ContextStackParser
         foreach ($segments as $segment) {
             $tag = $segment->tag();
 
-            if (array_key_exists($tag, self::CONTEXT_TAGS)) {
+            if ($this->rules->isContextTag($tag)) {
                 $context = new ContextSegment($segment);
 
                 // Pop previous context since this is a new one at the same level
@@ -56,7 +44,7 @@ final class ContextStackParser
                 continue;
             }
 
-            if (array_key_exists($tag, self::CHILD_TAGS) && $stack !== []) {
+            if ($this->rules->isChildTag($tag) && $stack !== []) {
                 $stack[array_key_last($stack)]->addChild($segment);
                 continue;
             }

--- a/src/EdifactParser.php
+++ b/src/EdifactParser.php
@@ -11,8 +11,11 @@ use EdifactParser\Segments\SegmentFactoryInterface;
 
 final class EdifactParser
 {
-    public function __construct(private SegmentFactoryInterface $segmentFactory)
+    private GroupingRules $groupingRules;
+
+    public function __construct(private SegmentFactoryInterface $segmentFactory, ?GroupingRules $groupingRules = null)
     {
+        $this->groupingRules = $groupingRules ?? GroupingRules::default();
     }
 
     /**
@@ -39,7 +42,7 @@ final class EdifactParser
         $segmentList = new SegmentList($this->segmentFactory);
         $segments = $segmentList->fromRaw($parser->get());
 
-        return TransactionMessage::groupSegmentsByMessage(...$segments);
+        return TransactionMessage::groupSegmentsByMessage($this->groupingRules, ...$segments);
     }
 
     public function parseFile(string $filePath): ParserResult

--- a/src/GroupingRules.php
+++ b/src/GroupingRules.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser;
+
+use function in_array;
+
+/**
+ * Configurable rules that drive how segments are grouped into context hierarchies
+ * and line-item sections. Defaults match the standard behaviour; pass a customized
+ * instance to {@see EdifactParser} to change context parents/children or the tags
+ * that close a line-item section.
+ */
+final class GroupingRules
+{
+    /**
+     * @param list<string> $contextTags Tags that open a context (parent) segment
+     * @param list<string> $childTags Tags attached as children to the open context
+     * @param list<string> $breakLineItemTags Tags that end the line-item section
+     */
+    public function __construct(
+        private array $contextTags = ['NAD', 'LIN', 'DOC'],
+        private array $childTags = ['COM', 'CTA', 'PIA', 'IMD', 'MEA', 'QTY', 'PRI', 'TAX', 'DTM', 'MOA'],
+        private array $breakLineItemTags = ['UNS', 'CNT', 'UNT'],
+    ) {
+    }
+
+    public static function default(): self
+    {
+        return new self();
+    }
+
+    /**
+     * @param list<string> $contextTags
+     */
+    public function withContextTags(array $contextTags): self
+    {
+        $clone = clone $this;
+        $clone->contextTags = $contextTags;
+
+        return $clone;
+    }
+
+    /**
+     * @param list<string> $childTags
+     */
+    public function withChildTags(array $childTags): self
+    {
+        $clone = clone $this;
+        $clone->childTags = $childTags;
+
+        return $clone;
+    }
+
+    /**
+     * @param list<string> $breakLineItemTags
+     */
+    public function withBreakLineItemTags(array $breakLineItemTags): self
+    {
+        $clone = clone $this;
+        $clone->breakLineItemTags = $breakLineItemTags;
+
+        return $clone;
+    }
+
+    public function isContextTag(string $tag): bool
+    {
+        return in_array($tag, $this->contextTags, true);
+    }
+
+    public function isChildTag(string $tag): bool
+    {
+        return in_array($tag, $this->childTags, true);
+    }
+
+    public function isBreakLineItemTag(string $tag): bool
+    {
+        return in_array($tag, $this->breakLineItemTags, true);
+    }
+}

--- a/src/MessageDataBuilder/Builder.php
+++ b/src/MessageDataBuilder/Builder.php
@@ -4,26 +4,21 @@ declare(strict_types=1);
 
 namespace EdifactParser\MessageDataBuilder;
 
+use EdifactParser\GroupingRules;
 use EdifactParser\LineItem;
 use EdifactParser\Segments\LINLineItem;
 use EdifactParser\Segments\SegmentInterface;
 use EdifactParser\Segments\UNSSectionControl;
 
-use function in_array;
-
 final class Builder
 {
     use MultipleBuilderWrapper;
 
-    /**
-     * Tags that indicate the end of a line item section.
-     * After one of these tags is found all following segments are
-     * considered part of the summary until another LIN tag appears.
-     */
-    private const BREAK_LINEITEM_TAGS = ['UNS', 'CNT', 'UNT'];
+    private GroupingRules $rules;
 
-    public function __construct()
+    public function __construct(?GroupingRules $rules = null)
     {
+        $this->rules = $rules ?? GroupingRules::default();
         $this->setCurrentBuilder(new SimpleBuilder());
     }
 
@@ -92,7 +87,7 @@ final class Builder
             return false;
         }
 
-        if (in_array($segment->tag(), self::BREAK_LINEITEM_TAGS, true)) {
+        if ($this->rules->isBreakLineItemTag($segment->tag())) {
             if ($segment instanceof UNSSectionControl) {
                 return $segment->indicatesEndOfDetailsSection();
             }

--- a/src/TransactionMessage.php
+++ b/src/TransactionMessage.php
@@ -23,19 +23,33 @@ final class TransactionMessage implements Countable
      * @param  array<string, array<string, SegmentInterface>>  $groupedSegments
      * @param  array<int|string, LineItem>  $lineItems
      * @param  list<ContextSegment>  $contextSegments
+     * @param  list<SegmentInterface>  $segments  Every segment in original order, duplicates preserved
      */
     public function __construct(
         private array $groupedSegments,
         private array $lineItems = [],
         private array $contextSegments = [],
+        private array $segments = [],
     ) {
+    }
+
+    /**
+     * Every segment of the message in original order, with duplicates preserved
+     * (unlike the keyed views, which index by tag+subId). Feed this to the
+     * serializer to round-trip a message.
+     *
+     * @return list<SegmentInterface>
+     */
+    public function segments(): array
+    {
+        return $this->segments;
     }
 
     /**
      * A transaction message starts with the "UNHMessageHeader" segment and finalizes with
      * the "UNTMessageFooter" segment, this process is repeated for each pair of segments.
      */
-    public static function groupSegmentsByMessage(SegmentInterface ...$segments): ParserResult
+    public static function groupSegmentsByMessage(GroupingRules $rules, SegmentInterface ...$segments): ParserResult
     {
         $messages = [];
         $groupedSegments = [];
@@ -67,7 +81,7 @@ final class TransactionMessage implements Countable
             $groupedSegments[] = $segment;
 
             if ($segment instanceof UNTMessageFooter) {
-                $message = self::groupSegmentsByName(...$groupedSegments);
+                $message = self::groupSegmentsByName($rules, ...$groupedSegments);
                 $messages[] = $message;
 
                 if ($openHeader !== null) {
@@ -77,7 +91,7 @@ final class TransactionMessage implements Countable
         }
 
         return new ParserResult(
-            self::filterGlobalSegments($segments),
+            self::filterGlobalSegments($rules, $segments),
             self::hasUnhSegment(...$messages),
             $functionalGroups,
         );
@@ -112,9 +126,31 @@ final class TransactionMessage implements Countable
         return $this->groupedSegments;
     }
 
+    /**
+     * A duplicate-preserving, ordered query over every segment of the message.
+     */
+    public function query(): SegmentQuery
+    {
+        if ($this->segments !== []) {
+            return new SegmentQuery($this->segments);
+        }
+
+        $flat = [];
+        foreach ($this->groupedSegments as $tagSegments) {
+            foreach ($tagSegments as $segment) {
+                $flat[] = $segment;
+            }
+        }
+
+        return new SegmentQuery($flat);
+    }
+
+    /**
+     * Total number of segments in the message (duplicates included).
+     */
     public function count(): int
     {
-        return count($this->groupedSegments);
+        return $this->segments !== [] ? count($this->segments) : count($this->groupedSegments);
     }
 
     /**
@@ -156,14 +192,14 @@ final class TransactionMessage implements Countable
     /**
      * @param list<SegmentInterface> $segments
      */
-    private static function filterGlobalSegments(array $segments): self
+    private static function filterGlobalSegments(GroupingRules $rules, array $segments): self
     {
         $globalMessages = array_filter(
             $segments,
             static fn (SegmentInterface $s) => in_array($s->tag(), ['UNA', 'UNB', 'UNZ'])
         );
 
-        return self::groupSegmentsByName(...$globalMessages);
+        return self::groupSegmentsByName($rules, ...$globalMessages);
     }
 
     /**
@@ -176,10 +212,10 @@ final class TransactionMessage implements Countable
         );
     }
 
-    private static function groupSegmentsByName(SegmentInterface ...$segments): self
+    private static function groupSegmentsByName(GroupingRules $rules, SegmentInterface ...$segments): self
     {
-        $builder = new MessageDataBuilder();
-        $contextParser = new ContextStackParser();
+        $builder = new MessageDataBuilder($rules);
+        $contextParser = new ContextStackParser($rules);
 
         foreach ($segments as $segment) {
             $builder->addSegment($segment);
@@ -202,6 +238,7 @@ final class TransactionMessage implements Countable
             $groupedSegments,
             $lineItems,
             $contexts,
+            array_values($segments),
         );
     }
 

--- a/src/Validation/MessageRuleSet.php
+++ b/src/Validation/MessageRuleSet.php
@@ -16,11 +16,13 @@ final class MessageRuleSet
     /**
      * @param list<string> $requiredTags
      * @param array<string, array{min: int, max: int|null}> $cardinality
+     * @param list<string> $sequence Expected relative order of the listed tags
      */
     public function __construct(
         private string $messageType,
         private array $requiredTags = [],
         private array $cardinality = [],
+        private array $sequence = [],
     ) {
     }
 
@@ -45,6 +47,17 @@ final class MessageRuleSet
         return $clone;
     }
 
+    /**
+     * Declare the expected relative order of the given tags. Other tags are ignored.
+     */
+    public function inSequence(string ...$tags): self
+    {
+        $clone = clone $this;
+        $clone->sequence = array_values($tags);
+
+        return $clone;
+    }
+
     public function messageType(): string
     {
         return $this->messageType;
@@ -64,5 +77,13 @@ final class MessageRuleSet
     public function cardinality(): array
     {
         return $this->cardinality;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function sequence(): array
+    {
+        return $this->sequence;
     }
 }

--- a/src/Validation/MessageValidator.php
+++ b/src/Validation/MessageValidator.php
@@ -45,11 +45,46 @@ final class MessageValidator
             }
         }
 
+        $sequenceViolation = $this->checkSequence($message, $rules);
+        if ($sequenceViolation !== null) {
+            $violations[] = $sequenceViolation;
+        }
+
         return $violations;
     }
 
     public function isValid(TransactionMessage $message, MessageRuleSet $rules): bool
     {
         return $this->validate($message, $rules) === [];
+    }
+
+    private function checkSequence(TransactionMessage $message, MessageRuleSet $rules): ?ValidationViolation
+    {
+        $sequence = $rules->sequence();
+        if ($sequence === []) {
+            return null;
+        }
+
+        $rank = array_flip($sequence);
+        $highest = -1;
+
+        foreach ($message->query()->get() as $segment) {
+            $tag = $segment->tag();
+            if (!isset($rank[$tag])) {
+                continue;
+            }
+
+            if ($rank[$tag] < $highest) {
+                return new ValidationViolation(
+                    $tag,
+                    'sequence',
+                    'Segments are not in the expected order: ' . implode(' -> ', $sequence),
+                );
+            }
+
+            $highest = $rank[$tag];
+        }
+
+        return null;
     }
 }

--- a/tests/Unit/Analysis/MessageAnalyzerTest.php
+++ b/tests/Unit/Analysis/MessageAnalyzerTest.php
@@ -364,7 +364,7 @@ EDI
     {
         $parser = (new Parser())->loadString($edifactContent);
         $segments = SegmentList::withDefaultFactory()->fromRaw($parser->get());
-        $result = TransactionMessage::groupSegmentsByMessage(...$segments);
+        $result = TransactionMessage::groupSegmentsByMessage(\EdifactParser\GroupingRules::default(), ...$segments);
 
         return $result->transactionMessages()[0];
     }

--- a/tests/Unit/GroupingRulesAndDuplicatesTest.php
+++ b/tests/Unit/GroupingRulesAndDuplicatesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit;
+
+use EdifactParser\EdifactParser;
+use EdifactParser\GroupingRules;
+use EdifactParser\Segments\SegmentFactory;
+use PHPUnit\Framework\TestCase;
+
+final class GroupingRulesAndDuplicatesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function query_preserves_duplicate_segments_with_the_same_tag_and_sub_id(): void
+    {
+        // Two RFF segments share tag+subId ('CU'); the keyed view keeps one, but
+        // query() and segments() must retain both.
+        $edi = "UNH+1+ORDERS:D:96A:UN'RFF+CU:A'RFF+CU:B'UNT+4+1'";
+
+        $message = EdifactParser::createWithDefaultSegments()->parse($edi)->transactionMessages()[0];
+
+        self::assertCount(2, $message->query()->withTag('RFF')->get());
+        self::assertCount(4, $message->segments());
+        self::assertSame(4, $message->count());
+        // The keyed single lookup still resolves (to the last one).
+        self::assertNotNull($message->segmentByTagAndSubId('RFF', 'CU'));
+    }
+
+    /**
+     * @test
+     */
+    public function custom_grouping_rules_change_context_detection(): void
+    {
+        $edi = "UNH+1+ORDERS:D:96A:UN'NAD+BY'CTA+IC'UNT+4+1'";
+
+        $default = EdifactParser::createWithDefaultSegments()->parse($edi)->transactionMessages()[0];
+        self::assertCount(1, $default->contextSegments());
+
+        // Remove NAD as a context parent: no context hierarchy is built.
+        $rules = GroupingRules::default()->withContextTags([]);
+        $custom = new EdifactParser(SegmentFactory::withDefaultSegments(), $rules);
+
+        $customMessage = $custom->parse($edi)->transactionMessages()[0];
+        self::assertCount(0, $customMessage->contextSegments());
+    }
+}

--- a/tests/Unit/TransactionMessageTest.php
+++ b/tests/Unit/TransactionMessageTest.php
@@ -37,7 +37,10 @@ final class TransactionMessageTest extends TestCase
                 'UNT' => [
                     '19' => new UNTMessageFooter(['UNT', '19', '1']),
                 ],
-            ], [], []),
+            ], [], [], [
+                new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
+                new UNTMessageFooter(['UNT', '19', '1']),
+            ]),
         ], $this->parse($fileContent)->transactionMessages());
     }
 
@@ -61,7 +64,10 @@ EDI;
                 'UNT' => [
                     '19' => new UNTMessageFooter(['UNT', '19', '1']),
                 ],
-            ], [], []),
+            ], [], [], [
+                new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
+                new UNTMessageFooter(['UNT', '19', '1']),
+            ]),
             new TransactionMessage([
                 'UNH' => [
                     '2' => new UNHMessageHeader(['UNH', '2', ['IFTMIN', 'S', '94A', 'UN', 'PN002']]),
@@ -69,7 +75,10 @@ EDI;
                 'UNT' => [
                     '19' => new UNTMessageFooter(['UNT', '19', '2']),
                 ],
-            ], [], []),
+            ], [], [], [
+                new UNHMessageHeader(['UNH', '2', ['IFTMIN', 'S', '94A', 'UN', 'PN002']]),
+                new UNTMessageFooter(['UNT', '19', '2']),
+            ]),
         ], $this->parse($fileContent)->transactionMessages());
     }
 
@@ -99,7 +108,13 @@ EDI;
                     '11' => new CNTControl(['CNT', ['11', '1', 'PCE']]),
                     '15' => new CNTControl(['CNT', ['15', '0.068224', 'MTQ']]),
                 ],
-            ], [], []),
+            ], [], [], [
+                new UNHMessageHeader(['UNH', '1', ['IFTMIN', 'S', '93A', 'UN', 'PN001']]),
+                new CNTControl(['CNT', ['7', '0.1', 'KGM']]),
+                new CNTControl(['CNT', ['11', '1', 'PCE']]),
+                new CNTControl(['CNT', ['15', '0.068224', 'MTQ']]),
+                new UNTMessageFooter(['UNT', '19', '1']),
+            ]),
         ], $this->parse($fileContent)->transactionMessages());
     }
 
@@ -129,7 +144,11 @@ EDI;
                 'UNT' => [
                     '19' => new UNTMessageFooter(['UNT', '19', '1']),
                 ],
-            ], [], []),
+            ], [], [], [
+                new UNHMessageHeader(['UNH', '1', 'anything']),
+                new CNTControl(['CNT', ['7', '0.1', 'KGM']]),
+                new UNTMessageFooter(['UNT', '19', '1']),
+            ]),
             new TransactionMessage([
                 'UNH' => [
                     '2' => new UNHMessageHeader(['UNH', '2', 'anything']),
@@ -137,7 +156,10 @@ EDI;
                 'UNT' => [
                     '19' => new UNTMessageFooter(['UNT', '19', '2']),
                 ],
-            ], [], []),
+            ], [], [], [
+                new UNHMessageHeader(['UNH', '2', 'anything']),
+                new UNTMessageFooter(['UNT', '19', '2']),
+            ]),
         ], $this->parse($fileContent)->transactionMessages());
     }
 
@@ -166,7 +188,11 @@ EDI;
                 'UNT' => [
                     '10' => new UNTMessageFooter(['UNT', '10', '2']),
                 ],
-            ], [], []),
+            ], [], [], [
+                new UNHMessageHeader(['UNH', '2', 'anything']),
+                new CNTControl(['CNT', ['5', '0.1', 'KGM']]),
+                new UNTMessageFooter(['UNT', '10', '2']),
+            ]),
         ], $this->parse($fileContent)->transactionMessages());
     }
 
@@ -217,7 +243,10 @@ EDI;
             'UNZ' => [
                 '2' => new UnknownSegment(['UNZ', '2', '3']),
             ],
-        ], [], []), $parerResult->globalSegments());
+        ], [], [], [
+            new UNBInterchangeHeader(['UNB', ['UNOC', '0'], ['1', '2'], ['3', '4'], '5', 'Anything here', '6']),
+            new UnknownSegment(['UNZ', '2', '3']),
+        ]), $parerResult->globalSegments());
 
         self::assertEquals([
             'UNH' => [
@@ -407,6 +436,6 @@ EDI;
         $segments = SegmentList::withDefaultFactory()
             ->fromRaw($parser->get());
 
-        return TransactionMessage::groupSegmentsByMessage(...$segments);
+        return TransactionMessage::groupSegmentsByMessage(\EdifactParser\GroupingRules::default(), ...$segments);
     }
 }

--- a/tests/Unit/Validation/MessageValidatorTest.php
+++ b/tests/Unit/Validation/MessageValidatorTest.php
@@ -54,6 +54,31 @@ final class MessageValidatorTest extends TestCase
         self::assertSame('cardinality', $violations[0]->rule());
         self::assertSame('cardinality', $violations[1]->rule());
     }
+
+    /**
+     * @test
+     */
+    public function accepts_segments_in_the_expected_sequence(): void
+    {
+        // In the sample: UNH ... BGM ... UNT appear in that order.
+        $rules = MessageRuleSet::forType('IFTMIN')->inSequence('UNH', 'BGM', 'UNT');
+
+        self::assertSame([], (new MessageValidator())->validate($this->sampleMessage(), $rules));
+    }
+
+    /**
+     * @test
+     */
+    public function reports_segments_out_of_sequence(): void
+    {
+        // BGM actually precedes UNT, so requiring UNT before BGM must fail.
+        $rules = MessageRuleSet::forType('IFTMIN')->inSequence('UNT', 'BGM');
+
+        $violations = (new MessageValidator())->validate($this->sampleMessage(), $rules);
+
+        self::assertCount(1, $violations);
+        self::assertSame('sequence', $violations[0]->rule());
+    }
     private function sampleMessage(): TransactionMessage
     {
         return EdifactParser::createWithDefaultSegments()


### PR DESCRIPTION
Completes the deferred 6.0 model work — the last three gaps toward a best-in-class EDIFACT library.

## Added
- **Injectable grouping rules** (`GroupingRules`): customize context parents/children and line-item-break tags via an optional 2nd `EdifactParser` constructor arg (was hardcoded consts). Closes #62.
- **Duplicate-segment preservation**: `TransactionMessage::query()` + new `segments()` keep every segment in order, dups included; `count()` reports the true total. Keyed views still index last-wins. Refs #59.
- **Sequence validation**: `MessageRuleSet::inSequence(...$tags)` + `MessageValidator` `sequence` violations. Refs #60.

## Breaking (see CHANGELOG migration)
- `EdifactParser::__construct($factory, ?GroupingRules)` — optional 2nd arg (1-arg calls unchanged).
- `TransactionMessage::groupSegmentsByMessage(GroupingRules, ...$segments)` — rules first.
- `TransactionMessage::__construct(...)` — optional 4th `$segments` arg.
- `count()` now returns total segments; `query()` preserves duplicates.

Gate green: psalm/phpstan/rector + 148 tests. Targets **6.0.0**.