### PR TITLE
feat: envelope metadata accessors + UNA-aware streaming (6.1.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ TransactionMessage organizes segments three ways:
 
 - **Typed accessors** on segments: e.g. `NADNameAddress::name()/countryCode()`,
   `QTYQuantity::quantityAsFloat()`, `PRIPrice::priceAsFloat()`, `DTMDateTimePeriod::asDateTime()`
+- **Envelope metadata**: `UNBInterchangeHeader` (syntax id/version, sender/recipient,
+  prep date/time, control ref), `UNZInterchangeTrailer`, `UNTMessageFooter`, `BGMBeginningOfMessage`
 - **`SegmentQuery`** (`$message->query()`): fluent `withTag/withTags/withSubId/where/ofType/
   limit/skip/first/last/get/count/exists/isEmpty/map/each`
 - **`Analysis\MessageAnalyzer`**: counts, `getPartyQualifiers()`, `getCurrencies()`,
@@ -76,7 +78,7 @@ TransactionMessage organizes segments three ways:
   every segment in order (dups included); keyed views index by tag+subId (last wins)
 - **Grouping config** (`GroupingRules`): injectable context/child/line-item-break tags
 - **Streaming** (`StreamingParser`): generator yielding one `TransactionMessage` at a time,
-  bounded memory for large interchanges
+  bounded memory for large interchanges; honours a leading `UNA` (custom delimiters)
 - **Functional groups** (`ParserResult::functionalGroups()` → `FunctionalGroup`): UNG/UNE
   envelope; messages also stay available flat via `transactionMessages()`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0] - 2026-07-22
+
+#### Added
+- **Rich envelope metadata accessors**:
+  - `UNBInterchangeHeader`: `syntaxIdentifier()`, `syntaxVersionNumber()`,
+    `senderIdentification()`, `recipientIdentification()`, `preparationDate()`,
+    `preparationTime()`, `interchangeControlReference()`.
+  - New typed `UNZInterchangeTrailer` (registered by default) with
+    `interchangeControlCount()` / `interchangeControlReference()`.
+  - `UNTMessageFooter`: `segmentCount()`, `messageReferenceNumber()`.
+  - `BGMBeginningOfMessage`: `documentCode()`, `documentNumber()`, `messageFunction()`.
+- **`StreamingParser` honours a leading `UNA`**: custom separators and release char
+  declared in the service-string advice are used when splitting (previously the
+  default `'`/`?` were assumed).
+
 ## [6.0.0] - 2026-07-22
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -406,6 +406,35 @@ foreach ($result->transactionMessages() as $message) {
 }
 ```
 
+### Interchange & Envelope Metadata
+
+The envelope segments expose typed accessors for their metadata:
+
+```php
+// UNB interchange header (from the global segments)
+$unb = $result->globalSegments()->segmentByTagAndSubId('UNB', 'UNOC');
+$unb->syntaxIdentifier();            // 'UNOC' (character set)
+$unb->senderIdentification();        // interchange sender
+$unb->recipientIdentification();     // interchange recipient
+$unb->preparationDate();             // 'YYMMDD'
+$unb->interchangeControlReference(); // sender-assigned reference
+
+// UNZ interchange trailer
+$unz = $result->globalSegments()->segmentByTagAndSubId('UNZ', '2');
+$unz->interchangeControlCount();     // number of messages/groups
+$unz->interchangeControlReference(); // matches the UNB
+
+// UNT trailer and BGM, per message
+$unt = $message->query()->withTag('UNT')->first();
+$unt->segmentCount();                // segment count of the message
+$bgm = $message->query()->withTag('BGM')->first();
+$bgm->documentCode();                // e.g. '220' (order), '380' (invoice)
+$bgm->documentNumber();
+```
+
+> `StreamingParser` reads a leading `UNA` service-string advice and honours its
+> custom separators and release character automatically.
+
 ### Functional Groups (UNG/UNE)
 
 When an interchange wraps messages in `UNG...UNE` functional groups, access them

--- a/src/Segments/AbstractSegment.php
+++ b/src/Segments/AbstractSegment.php
@@ -91,4 +91,14 @@ abstract class AbstractSegment implements SegmentInterface
 
         return is_array($value) ? (string) ($value[$index] ?? '') : '';
     }
+
+    /**
+     * Read simple element $index (a non-composite value), '' when absent or composite.
+     */
+    protected function element(int $index): string
+    {
+        $value = $this->rawValues[$index] ?? '';
+
+        return is_array($value) ? '' : (string) $value;
+    }
 }

--- a/src/Segments/BGMBeginningOfMessage.php
+++ b/src/Segments/BGMBeginningOfMessage.php
@@ -11,4 +11,28 @@ final class BGMBeginningOfMessage extends AbstractSegment
     {
         return 'BGM';
     }
+
+    /**
+     * Document/message name code (e.g., '220' = Order, '380' = Invoice, '351' = Despatch advice)
+     */
+    public function documentCode(): string
+    {
+        return $this->component(0);
+    }
+
+    /**
+     * Document/message number (buyer/sender reference for the document)
+     */
+    public function documentNumber(): string
+    {
+        return $this->element(2);
+    }
+
+    /**
+     * Message function code (e.g., '9' = Original, '7' = Duplicate, '3' = Deletion)
+     */
+    public function messageFunction(): string
+    {
+        return $this->element(3);
+    }
 }

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -36,6 +36,7 @@ final class SegmentFactory implements SegmentFactoryInterface
         'MOA' => MOAMonetaryAmount::class,
         'UNG' => UNGFunctionalGroupHeader::class,
         'UNE' => UNEFunctionalGroupTrailer::class,
+        'UNZ' => UNZInterchangeTrailer::class,
     ];
 
     private const TAG_LENGTH = 3;

--- a/src/Segments/UNBInterchangeHeader.php
+++ b/src/Segments/UNBInterchangeHeader.php
@@ -16,4 +16,60 @@ final class UNBInterchangeHeader extends AbstractSegment
     {
         return $this->requiredSubId();
     }
+
+    /**
+     * Syntax identifier / character set (e.g., 'UNOA', 'UNOB', 'UNOC', 'UNOY' = UTF-8)
+     */
+    public function syntaxIdentifier(): string
+    {
+        return $this->component(0);
+    }
+
+    /**
+     * Syntax version number (e.g., '1', '2', '3', '4')
+     */
+    public function syntaxVersionNumber(): string
+    {
+        return $this->component(1);
+    }
+
+    /**
+     * Interchange sender identification
+     */
+    public function senderIdentification(): string
+    {
+        return $this->component(0, 2);
+    }
+
+    /**
+     * Interchange recipient identification
+     */
+    public function recipientIdentification(): string
+    {
+        return $this->component(0, 3);
+    }
+
+    /**
+     * Preparation date (YYMMDD or CCYYMMDD depending on syntax version)
+     */
+    public function preparationDate(): string
+    {
+        return $this->component(0, 4);
+    }
+
+    /**
+     * Preparation time (HHMM)
+     */
+    public function preparationTime(): string
+    {
+        return $this->component(1, 4);
+    }
+
+    /**
+     * Interchange control reference (sender-assigned, unique per interchange)
+     */
+    public function interchangeControlReference(): string
+    {
+        return $this->element(5);
+    }
 }

--- a/src/Segments/UNTMessageFooter.php
+++ b/src/Segments/UNTMessageFooter.php
@@ -11,4 +11,20 @@ final class UNTMessageFooter extends AbstractSegment
     {
         return 'UNT';
     }
+
+    /**
+     * Number of segments in the message (including UNH and UNT)
+     */
+    public function segmentCount(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Message reference number (must match the UNH)
+     */
+    public function messageReferenceNumber(): string
+    {
+        return $this->element(2);
+    }
 }

--- a/src/Segments/UNZInterchangeTrailer.php
+++ b/src/Segments/UNZInterchangeTrailer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class UNZInterchangeTrailer extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'UNZ';
+    }
+
+    /**
+     * Interchange control count: number of messages (or functional groups) in the interchange
+     */
+    public function interchangeControlCount(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Interchange control reference (must match the UNB)
+     */
+    public function interchangeControlReference(): string
+    {
+        return $this->element(2);
+    }
+}

--- a/src/StreamingParser.php
+++ b/src/StreamingParser.php
@@ -22,11 +22,14 @@ use function trim;
  * interchanges parse in bounded memory — unlike {@see EdifactParser} which builds
  * the whole result up front.
  *
- * Assumes the default segment terminator (`'`) and release char (`?`).
+ * A leading `UNA` service-string advice is honoured — custom separators and
+ * release char declared there are used for splitting. Otherwise the constructor
+ * defaults (`'` terminator, `?` release) apply.
  */
 final class StreamingParser
 {
     private const CHUNK_BYTES = 8192;
+    private const UNA_LENGTH = 9;
 
     public function __construct(
         private EdifactParser $parser,
@@ -68,6 +71,10 @@ final class StreamingParser
         $buffer = '';
         $message = [];
         $inMessage = false;
+        $terminator = $this->segmentTerminator;
+        $release = $this->releaseCharacter;
+        $unaPrefix = '';
+        $unaChecked = false;
 
         while (!feof($handle)) {
             $chunk = fread($handle, self::CHUNK_BYTES);
@@ -77,7 +84,15 @@ final class StreamingParser
 
             $buffer .= $chunk;
 
-            foreach ($this->extractSegments($buffer) as $segment) {
+            if (!$unaChecked && strlen($buffer) >= self::UNA_LENGTH) {
+                $unaChecked = true;
+                $una = $this->detectUna($buffer);
+                if ($una !== null) {
+                    [$terminator, $release, $buffer, $unaPrefix] = $una;
+                }
+            }
+
+            foreach ($this->extractSegments($buffer, $terminator, $release) as $segment) {
                 $tag = strtoupper(substr($segment, 0, 3));
 
                 if ($tag === 'UNH') {
@@ -91,7 +106,7 @@ final class StreamingParser
                 }
 
                 if ($tag === 'UNT') {
-                    $text = implode($this->segmentTerminator, $message) . $this->segmentTerminator;
+                    $text = $unaPrefix . implode($terminator, $message) . $terminator;
                     yield from $this->parser->parse($text)->transactionMessages();
 
                     $message = [];
@@ -102,12 +117,33 @@ final class StreamingParser
     }
 
     /**
+     * Detects a leading UNA service-string advice and returns
+     * [terminator, release, buffer-without-una, una-string], or null when there is no UNA.
+     * The UNA string is prepended to each message so the batch parser reuses the
+     * declared delimiters.
+     *
+     * @return array{0: string, 1: string, 2: string, 3: string}|null
+     */
+    private function detectUna(string $buffer): ?array
+    {
+        $offset = strspn($buffer, " \t\r\n");
+
+        if (substr($buffer, $offset, 3) !== 'UNA' || strlen($buffer) < $offset + self::UNA_LENGTH) {
+            return null;
+        }
+
+        $una = substr($buffer, $offset, self::UNA_LENGTH);
+
+        return [$una[8], $una[6], substr($buffer, $offset + self::UNA_LENGTH), $una];
+    }
+
+    /**
      * Splits complete segments out of the buffer, leaving the trailing partial
      * segment (and its escape state) in place for the next read.
      *
      * @return list<string>
      */
-    private function extractSegments(string &$buffer): array
+    private function extractSegments(string &$buffer, string $terminator, string $release): array
     {
         $segments = [];
         $current = '';
@@ -123,13 +159,13 @@ final class StreamingParser
                 continue;
             }
 
-            if ($char === $this->releaseCharacter) {
+            if ($char === $release) {
                 $current .= $char;
                 $escaped = true;
                 continue;
             }
 
-            if ($char === $this->segmentTerminator) {
+            if ($char === $terminator) {
                 $trimmed = trim($current);
                 if ($trimmed !== '') {
                     $segments[] = $trimmed;

--- a/tests/Unit/EnvelopeMetadataTest.php
+++ b/tests/Unit/EnvelopeMetadataTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit;
+
+use EdifactParser\EdifactParser;
+use EdifactParser\ParserResult;
+use EdifactParser\Segments\BGMBeginningOfMessage;
+use EdifactParser\Segments\UNBInterchangeHeader;
+use EdifactParser\Segments\UNTMessageFooter;
+use EdifactParser\Segments\UNZInterchangeTrailer;
+use PHPUnit\Framework\TestCase;
+
+final class EnvelopeMetadataTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function unb_interchange_header_metadata(): void
+    {
+        $unb = $this->sample()->globalSegments()->segmentByTagAndSubId('UNB', 'UNOC');
+
+        self::assertInstanceOf(UNBInterchangeHeader::class, $unb);
+        self::assertSame('UNOC', $unb->syntaxIdentifier());
+        self::assertSame('3', $unb->syntaxVersionNumber());
+        self::assertSame('9457386', $unb->senderIdentification());
+        self::assertSame('73130012', $unb->recipientIdentification());
+        self::assertSame('19101', $unb->preparationDate());
+        self::assertSame('118', $unb->preparationTime());
+        self::assertSame('8', $unb->interchangeControlReference());
+    }
+
+    /**
+     * @test
+     */
+    public function unz_interchange_trailer_metadata(): void
+    {
+        $unz = $this->sample()->globalSegments()->segmentByTagAndSubId('UNZ', '2');
+
+        self::assertInstanceOf(UNZInterchangeTrailer::class, $unz);
+        self::assertSame('2', $unz->interchangeControlCount());
+        self::assertSame('8', $unz->interchangeControlReference());
+    }
+
+    /**
+     * @test
+     */
+    public function unt_and_bgm_metadata(): void
+    {
+        $message = $this->sample()->transactionMessages()[0];
+
+        $unt = $message->query()->withTag('UNT')->first();
+        self::assertInstanceOf(UNTMessageFooter::class, $unt);
+        self::assertSame('18', $unt->segmentCount());
+        self::assertSame('1', $unt->messageReferenceNumber());
+
+        $bgm = $message->query()->withTag('BGM')->first();
+        self::assertInstanceOf(BGMBeginningOfMessage::class, $bgm);
+        self::assertSame('220', $bgm->documentCode());
+        self::assertSame('56677786689', $bgm->documentNumber());
+        self::assertSame('9', $bgm->messageFunction());
+    }
+    private function sample(): ParserResult
+    {
+        return EdifactParser::createWithDefaultSegments()->parseFile(__DIR__ . '/../../example/edifact-sample.edi');
+    }
+}

--- a/tests/Unit/StreamingParserTest.php
+++ b/tests/Unit/StreamingParserTest.php
@@ -66,4 +66,27 @@ final class StreamingParserTest extends TestCase
             @unlink($path);
         }
     }
+
+    /**
+     * @test
+     */
+    public function honours_a_leading_una_with_custom_delimiters(): void
+    {
+        // Custom segment terminator '~' declared by the UNA service-string advice.
+        $edi = 'UNA:+.? ~UNB+UNOC:3+S+R+200101:1200+1~UNH+1+ORDERS:D:96A:UN~BGM+220~UNT+3+1~UNZ+1+1~';
+        $path = (string) tempnam(sys_get_temp_dir(), 'edi');
+        file_put_contents($path, $edi);
+
+        try {
+            $messages = [];
+            foreach (StreamingParser::createWithDefaultSegments()->parseFile($path) as $message) {
+                $messages[] = $message;
+            }
+
+            self::assertCount(1, $messages);
+            self::assertSame('ORDERS', $messages[0]->messageType());
+        } finally {
+            @unlink($path);
+        }
+    }
 }

--- a/tests/Unit/TransactionMessageTest.php
+++ b/tests/Unit/TransactionMessageTest.php
@@ -17,6 +17,7 @@ use EdifactParser\Segments\UNBInterchangeHeader;
 use EdifactParser\Segments\UNHMessageHeader;
 use EdifactParser\Segments\UnknownSegment;
 use EdifactParser\Segments\UNTMessageFooter;
+use EdifactParser\Segments\UNZInterchangeTrailer;
 use EdifactParser\TransactionMessage;
 use PHPUnit\Framework\TestCase;
 
@@ -241,11 +242,11 @@ EDI;
                 ),
             ],
             'UNZ' => [
-                '2' => new UnknownSegment(['UNZ', '2', '3']),
+                '2' => new UNZInterchangeTrailer(['UNZ', '2', '3']),
             ],
         ], [], [], [
             new UNBInterchangeHeader(['UNB', ['UNOC', '0'], ['1', '2'], ['3', '4'], '5', 'Anything here', '6']),
-            new UnknownSegment(['UNZ', '2', '3']),
+            new UNZInterchangeTrailer(['UNZ', '2', '3']),
         ]), $parerResult->globalSegments());
 
         self::assertEquals([


### PR DESCRIPTION
Rounds out EDIFACT coverage with envelope metadata and correct custom-delimiter streaming.

## Added
- **Envelope accessors**: `UNB` (syntax id/version, sender, recipient, prep date/time, control ref), new typed `UNZInterchangeTrailer` (registered), `UNT` (segment count, message ref), `BGM` (document code/number, message function). New `AbstractSegment::element()` helper for simple elements.
- **UNA-aware streaming**: `StreamingParser` reads a leading `UNA` and honours its custom separators/release char (previously assumed default `'`/`?`), prepending it to each message so the batch parser reuses the declared delimiters.

Additive → 6.1.0. Gate green: psalm/phpstan/rector + 152 tests.