### PR TITLE
feat: interchange assembly builder (write full UNB…UNZ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.0] - 2026-07-22
+
+#### Added
+- **Interchange assembly** (`Writer\InterchangeBuilder` + `Writer\MessageBuilder`):
+  build a full UNB…UNZ interchange programmatically with **auto-computed UNT segment
+  counts and UNZ interchange control count**, then `toString()` to a ready-to-send
+  EDIFACT string. Completes the write path alongside the fluent segment builders.
+
 ## [6.1.0] - 2026-07-22
 
 #### Added

--- a/src/Segments/AbstractSegment.php
+++ b/src/Segments/AbstractSegment.php
@@ -101,4 +101,16 @@ abstract class AbstractSegment implements SegmentInterface
 
         return is_array($value) ? '' : (string) $value;
     }
+
+    /**
+     * First component of element $group, or the element itself when it is simple.
+     * An element with a single value round-trips as a plain string, not a 1-tuple,
+     * so accessors for the leading component must handle both shapes.
+     */
+    protected function firstComponent(int $group): string
+    {
+        $value = $this->rawValues[$group] ?? '';
+
+        return is_array($value) ? (string) ($value[0] ?? '') : (string) $value;
+    }
 }

--- a/src/Segments/BGMBeginningOfMessage.php
+++ b/src/Segments/BGMBeginningOfMessage.php
@@ -17,7 +17,7 @@ final class BGMBeginningOfMessage extends AbstractSegment
      */
     public function documentCode(): string
     {
-        return $this->component(0);
+        return $this->firstComponent(1);
     }
 
     /**

--- a/src/Segments/UNBInterchangeHeader.php
+++ b/src/Segments/UNBInterchangeHeader.php
@@ -22,7 +22,7 @@ final class UNBInterchangeHeader extends AbstractSegment
      */
     public function syntaxIdentifier(): string
     {
-        return $this->component(0);
+        return $this->firstComponent(1);
     }
 
     /**
@@ -38,7 +38,7 @@ final class UNBInterchangeHeader extends AbstractSegment
      */
     public function senderIdentification(): string
     {
-        return $this->component(0, 2);
+        return $this->firstComponent(2);
     }
 
     /**
@@ -46,7 +46,7 @@ final class UNBInterchangeHeader extends AbstractSegment
      */
     public function recipientIdentification(): string
     {
-        return $this->component(0, 3);
+        return $this->firstComponent(3);
     }
 
     /**
@@ -54,7 +54,7 @@ final class UNBInterchangeHeader extends AbstractSegment
      */
     public function preparationDate(): string
     {
-        return $this->component(0, 4);
+        return $this->firstComponent(4);
     }
 
     /**

--- a/src/Writer/InterchangeBuilder.php
+++ b/src/Writer/InterchangeBuilder.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Writer;
+
+use EdifactParser\Segments\SegmentInterface;
+use EdifactParser\Segments\UNBInterchangeHeader;
+use EdifactParser\Segments\UNZInterchangeTrailer;
+use EdifactParser\Serializer\EdifactSerializer;
+use EdifactParser\Serializer\UnaSeparators;
+
+use function count;
+
+/**
+ * Assembles a complete interchange: UNB header, the messages, and a UNZ trailer with
+ * the interchange control count filled in automatically. Serialize the result to a
+ * ready-to-send EDIFACT string with {@see self::toString()}.
+ */
+final class InterchangeBuilder
+{
+    /** @var list<MessageBuilder> */
+    private array $messages = [];
+
+    private string $date = '';
+
+    private string $time = '';
+
+    private function __construct(
+        private string $sender,
+        private string $recipient,
+        private string $controlReference,
+        private string $syntaxIdentifier,
+        private string $syntaxVersion,
+    ) {
+    }
+
+    public static function create(
+        string $sender,
+        string $recipient,
+        string $controlReference,
+        string $syntaxIdentifier = 'UNOC',
+        string $syntaxVersion = '3',
+    ): self {
+        return new self($sender, $recipient, $controlReference, $syntaxIdentifier, $syntaxVersion);
+    }
+
+    public function preparedAt(string $date, string $time): self
+    {
+        $this->date = $date;
+        $this->time = $time;
+
+        return $this;
+    }
+
+    public function addMessage(MessageBuilder $message): self
+    {
+        $this->messages[] = $message;
+
+        return $this;
+    }
+
+    /**
+     * @return list<SegmentInterface> [UNB, ...messages, UNZ] with the interchange control count filled in
+     */
+    public function build(): array
+    {
+        $header = new UNBInterchangeHeader([
+            'UNB',
+            [$this->syntaxIdentifier, $this->syntaxVersion],
+            [$this->sender],
+            [$this->recipient],
+            [$this->date, $this->time],
+            $this->controlReference,
+        ]);
+
+        $segments = [$header];
+        foreach ($this->messages as $message) {
+            foreach ($message->build() as $segment) {
+                $segments[] = $segment;
+            }
+        }
+        $segments[] = new UNZInterchangeTrailer(['UNZ', (string) count($this->messages), $this->controlReference]);
+
+        return $segments;
+    }
+
+    public function toString(?UnaSeparators $una = null): string
+    {
+        return (new EdifactSerializer($una))->serialize($this->build(), includeUna: true);
+    }
+}

--- a/src/Writer/MessageBuilder.php
+++ b/src/Writer/MessageBuilder.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Writer;
+
+use EdifactParser\Segments\SegmentInterface;
+use EdifactParser\Segments\UNHMessageHeader;
+use EdifactParser\Segments\UNTMessageFooter;
+
+use function count;
+
+/**
+ * Assembles a single UNH...UNT message: prepend the header, append the trailer, and
+ * compute the UNT segment count automatically.
+ */
+final class MessageBuilder
+{
+    /** @var list<SegmentInterface> */
+    private array $segments = [];
+
+    private function __construct(
+        private string $reference,
+        private string $type,
+        private string $version,
+        private string $release,
+        private string $agency,
+    ) {
+    }
+
+    public static function create(
+        string $reference,
+        string $type,
+        string $version = 'D',
+        string $release = '96A',
+        string $agency = 'UN',
+    ): self {
+        return new self($reference, $type, $version, $release, $agency);
+    }
+
+    public function addSegment(SegmentInterface $segment): self
+    {
+        $this->segments[] = $segment;
+
+        return $this;
+    }
+
+    public function reference(): string
+    {
+        return $this->reference;
+    }
+
+    /**
+     * @return list<SegmentInterface> [UNH, ...body, UNT] with the UNT segment count filled in
+     */
+    public function build(): array
+    {
+        $header = new UNHMessageHeader(['UNH', $this->reference, [$this->type, $this->version, $this->release, $this->agency]]);
+        $segmentCount = count($this->segments) + 2; // body + UNH + UNT
+        $trailer = new UNTMessageFooter(['UNT', (string) $segmentCount, $this->reference]);
+
+        return [$header, ...$this->segments, $trailer];
+    }
+}

--- a/tests/Unit/Writer/InterchangeBuilderTest.php
+++ b/tests/Unit/Writer/InterchangeBuilderTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit\Writer;
+
+use EdifactParser\EdifactParser;
+use EdifactParser\Segments\BGMBeginningOfMessage;
+use EdifactParser\Segments\NADNameAddress;
+use EdifactParser\Segments\Qualifier\NADQualifier;
+use EdifactParser\Segments\UNBInterchangeHeader;
+use EdifactParser\Segments\UNTMessageFooter;
+use EdifactParser\Segments\UNZInterchangeTrailer;
+use EdifactParser\Writer\InterchangeBuilder;
+use EdifactParser\Writer\MessageBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class InterchangeBuilderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function builds_and_serializes_an_interchange_that_parses_back(): void
+    {
+        $edi = InterchangeBuilder::create('SENDER', 'RECIPIENT', 'REF1')
+            ->preparedAt('200101', '1200')
+            ->addMessage(
+                MessageBuilder::create('1', 'ORDERS')
+                    ->addSegment(new BGMBeginningOfMessage(['BGM', '220']))
+                    ->addSegment(NADNameAddress::builder()->withQualifier(NADQualifier::BUYER)->withName('ACME')->build())
+            )
+            ->toString();
+
+        $result = EdifactParser::createWithDefaultSegments()->parse($edi);
+
+        // One message, correct type
+        self::assertCount(1, $result->transactionMessages());
+        $message = $result->transactionMessages()[0];
+        self::assertSame('ORDERS', $message->messageType());
+
+        // UNT segment count is auto-computed: UNH + BGM + NAD + UNT = 4
+        $unt = $message->query()->withTag('UNT')->first();
+        self::assertInstanceOf(UNTMessageFooter::class, $unt);
+        self::assertSame('4', $unt->segmentCount());
+
+        // UNB metadata survives the round-trip
+        $unb = $result->globalSegments()->segmentByTagAndSubId('UNB', 'UNOC');
+        self::assertInstanceOf(UNBInterchangeHeader::class, $unb);
+        self::assertSame('SENDER', $unb->senderIdentification());
+        self::assertSame('RECIPIENT', $unb->recipientIdentification());
+
+        // UNZ interchange control count is auto-computed (1 message)
+        $unz = $result->globalSegments()->segmentByTagAndSubId('UNZ', '1');
+        self::assertInstanceOf(UNZInterchangeTrailer::class, $unz);
+        self::assertSame('1', $unz->interchangeControlCount());
+    }
+
+    /**
+     * @test
+     */
+    public function counts_multiple_messages(): void
+    {
+        $edi = InterchangeBuilder::create('S', 'R', 'REF')
+            ->addMessage(MessageBuilder::create('1', 'ORDERS')->addSegment(new BGMBeginningOfMessage(['BGM', '220'])))
+            ->addMessage(MessageBuilder::create('2', 'ORDERS')->addSegment(new BGMBeginningOfMessage(['BGM', '221'])))
+            ->toString();
+
+        $result = EdifactParser::createWithDefaultSegments()->parse($edi);
+
+        self::assertCount(2, $result->transactionMessages());
+        $unz = $result->globalSegments()->segmentByTagAndSubId('UNZ', '2');
+        self::assertInstanceOf(UNZInterchangeTrailer::class, $unz);
+        self::assertSame('2', $unz->interchangeControlCount());
+    }
+}


### PR DESCRIPTION
Completes the write path. Adds `Writer\InterchangeBuilder` + `Writer\MessageBuilder`: assemble a full interchange programmatically and serialize it, with **UNT segment counts and the UNZ control count computed automatically**.

```php
$edi = InterchangeBuilder::create('SENDER', 'RECIPIENT', 'REF1')
    ->addMessage(MessageBuilder::create('1', 'ORDERS')->addSegment($bgm)->addSegment($nad))
    ->toString();
```

Also adds `AbstractSegment::firstComponent()` so envelope accessors handle single-value elements that round-trip as plain strings. Additive → 6.2.0. Gate green: psalm/phpstan/rector + 154 tests.