### PR TITLE
feat: predefined validation rule sets (ORDERS/INVOIC/DESADV/IFTMIN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.2.0] - 2026-07-22
 
 #### Added
+- **Predefined validation rule sets** (`Validation\MessageRuleSets`): ready-to-use
+  `MessageRuleSet`s for `ORDERS`, `INVOIC`, `DESADV` and `IFTMIN` (mandatory segments
+  + typical order), extensible for partner-specific rules.
 - **Interchange assembly** (`Writer\InterchangeBuilder` + `Writer\MessageBuilder`):
   build a full UNB…UNZ interchange programmatically with **auto-computed UNT segment
   counts and UNZ interchange control count**, then `toString()` to a ready-to-send

--- a/src/Validation/MessageRuleSets.php
+++ b/src/Validation/MessageRuleSets.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Validation;
+
+/**
+ * Ready-to-use {@see MessageRuleSet}s for common UN/EDIFACT message types. These are
+ * pragmatic starting points (mandatory service segments + typical order), not full
+ * D.xx specifications — extend them with `->require()`, `->occurs()`, `->inSequence()`
+ * for your trading-partner requirements.
+ */
+final class MessageRuleSets
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Purchase order.
+     */
+    public static function orders(): MessageRuleSet
+    {
+        return MessageRuleSet::forType('ORDERS')
+            ->require('UNH', 'BGM', 'UNT')
+            ->occurs('BGM', 1, 1)
+            ->occurs('UNH', 1, 1)
+            ->occurs('UNT', 1, 1)
+            ->inSequence('UNH', 'BGM', 'DTM', 'NAD', 'LIN', 'UNS', 'CNT', 'UNT');
+    }
+
+    /**
+     * Invoice.
+     */
+    public static function invoic(): MessageRuleSet
+    {
+        return MessageRuleSet::forType('INVOIC')
+            ->require('UNH', 'BGM', 'UNT')
+            ->occurs('BGM', 1, 1)
+            ->occurs('UNH', 1, 1)
+            ->occurs('UNT', 1, 1)
+            ->inSequence('UNH', 'BGM', 'DTM', 'NAD', 'CUX', 'LIN', 'UNS', 'MOA', 'UNT');
+    }
+
+    /**
+     * Despatch advice.
+     */
+    public static function desadv(): MessageRuleSet
+    {
+        return MessageRuleSet::forType('DESADV')
+            ->require('UNH', 'BGM', 'UNT')
+            ->occurs('BGM', 1, 1)
+            ->occurs('UNH', 1, 1)
+            ->occurs('UNT', 1, 1)
+            ->inSequence('UNH', 'BGM', 'DTM', 'NAD', 'CPS', 'LIN', 'UNT');
+    }
+
+    /**
+     * Transport instruction (forwarding and transport).
+     */
+    public static function iftmin(): MessageRuleSet
+    {
+        return MessageRuleSet::forType('IFTMIN')
+            ->require('UNH', 'BGM', 'UNT')
+            ->occurs('BGM', 1, 1)
+            ->occurs('UNH', 1, 1)
+            ->occurs('UNT', 1, 1)
+            ->inSequence('UNH', 'BGM', 'DTM', 'NAD', 'UNT');
+    }
+}

--- a/tests/Unit/Validation/MessageRuleSetsTest.php
+++ b/tests/Unit/Validation/MessageRuleSetsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit\Validation;
+
+use EdifactParser\EdifactParser;
+use EdifactParser\Validation\MessageRuleSets;
+use EdifactParser\Validation\MessageValidator;
+use PHPUnit\Framework\TestCase;
+
+final class MessageRuleSetsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function the_iftmin_sample_conforms_to_the_predefined_iftmin_rule_set(): void
+    {
+        $message = EdifactParser::createWithDefaultSegments()
+            ->parseFile(__DIR__ . '/../../../example/edifact-sample.edi')
+            ->transactionMessages()[0];
+
+        self::assertTrue((new MessageValidator())->isValid($message, MessageRuleSets::iftmin()));
+    }
+
+    /**
+     * @test
+     */
+    public function orders_rule_set_flags_a_message_missing_the_mandatory_bgm(): void
+    {
+        $message = EdifactParser::createWithDefaultSegments()
+            ->parse("UNH+1+ORDERS:D:96A:UN'UNT+2+1'")
+            ->transactionMessages()[0];
+
+        $violations = (new MessageValidator())->validate($message, MessageRuleSets::orders());
+
+        self::assertNotEmpty($violations);
+        self::assertSame('BGM', $violations[0]->segmentTag());
+        self::assertSame('required', $violations[0]->rule());
+    }
+}


### PR DESCRIPTION
Adds `Validation\MessageRuleSets` — ready-to-use `MessageRuleSet`s so validation works out of the box, not only with hand-built rules. Pragmatic starting points (mandatory segments + typical order), extensible via `require()`/`occurs()`/`inSequence()`. Additive → 6.2.0.