### PR TITLE
feat: character-set decoding by UNB syntax identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.2.0] - 2026-07-22
 
 #### Added
+- **Character-set decoding** (`Charset\Charset`): map a UNB syntax identifier
+  (UNOA/UNOB → ASCII, UNOC → ISO-8859-1, … UNOY → UTF-8) to an encoding and decode
+  data values to UTF-8. `UNBInterchangeHeader::characterEncoding()` exposes the
+  interchange encoding. Adds an `ext-mbstring` requirement.
 - **Predefined validation rule sets** (`Validation\MessageRuleSets`): ready-to-use
   `MessageRuleSet`s for `ORDERS`, `INVOIC`, `DESADV` and `IFTMIN` (mandatory segments
   + typical order), extensible for partner-specific rules.

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "prefer-stable": true,
     "require": {
         "ext-json": "*",
+        "ext-mbstring": "*",
         "php": ">=8.0",
         "sabas/edifact": "^1.2",
         "webmozart/assert": "^1.12"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82a5a571c9c7b816ce9a3541874bdc38",
+    "content-hash": "b52f6fb6ab5f9a3d4174d40a762081de",
     "packages": [
         {
             "name": "sabas/edifact",
@@ -5607,6 +5607,7 @@
     "prefer-lowest": false,
     "platform": {
         "ext-json": "*",
+        "ext-mbstring": "*",
         "php": ">=8.0"
     },
     "platform-dev": {},

--- a/src/Charset/Charset.php
+++ b/src/Charset/Charset.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Charset;
+
+use function mb_convert_encoding;
+use function strtoupper;
+
+/**
+ * Maps EDIFACT syntax identifiers (UNB element S001) to character encodings and
+ * decodes values to UTF-8. The parser reads raw bytes; use this with the
+ * interchange's syntax identifier to normalize non-ASCII data.
+ */
+final class Charset
+{
+    /** @var array<string, string> */
+    private const ENCODINGS = [
+        'UNOA' => 'ASCII',        // level A: restricted ASCII
+        'UNOB' => 'ASCII',        // level B: ASCII
+        'UNOC' => 'ISO-8859-1',   // Latin-1 (Western European)
+        'UNOD' => 'ISO-8859-2',   // Latin-2 (Central European)
+        'UNOE' => 'ISO-8859-5',   // Cyrillic
+        'UNOF' => 'ISO-8859-7',   // Greek
+        'UNOG' => 'ISO-8859-3',   // Latin-3
+        'UNOH' => 'ISO-8859-4',   // Latin-4
+        'UNOI' => 'ISO-8859-6',   // Arabic
+        'UNOJ' => 'ISO-8859-8',   // Hebrew
+        'UNOK' => 'ISO-8859-9',   // Latin-5 (Turkish)
+        'UNOY' => 'UTF-8',        // UTF-8
+    ];
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * PHP encoding name for a syntax identifier; UTF-8 for unknown identifiers.
+     *
+     * @psalm-pure
+     */
+    public static function encodingFor(string $syntaxIdentifier): string
+    {
+        return self::ENCODINGS[strtoupper($syntaxIdentifier)] ?? 'UTF-8';
+    }
+
+    /**
+     * Decode a value from the encoding of the given syntax identifier to UTF-8.
+     */
+    public static function toUtf8(string $value, string $syntaxIdentifier): string
+    {
+        $encoding = self::encodingFor($syntaxIdentifier);
+
+        if ($encoding === 'UTF-8') {
+            return $value;
+        }
+
+        // $encoding always comes from the map above, so the conversion cannot fail.
+        return mb_convert_encoding($value, 'UTF-8', $encoding);
+    }
+}

--- a/src/Segments/UNBInterchangeHeader.php
+++ b/src/Segments/UNBInterchangeHeader.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EdifactParser\Segments;
 
+use EdifactParser\Charset\Charset;
+
 /** @psalm-immutable */
 final class UNBInterchangeHeader extends AbstractSegment
 {
@@ -71,5 +73,14 @@ final class UNBInterchangeHeader extends AbstractSegment
     public function interchangeControlReference(): string
     {
         return $this->element(5);
+    }
+
+    /**
+     * PHP character encoding implied by the syntax identifier (e.g., 'ISO-8859-1').
+     * Use with {@see Charset::toUtf8()} to normalize non-ASCII data values.
+     */
+    public function characterEncoding(): string
+    {
+        return Charset::encodingFor($this->syntaxIdentifier());
     }
 }

--- a/tests/Unit/Charset/CharsetTest.php
+++ b/tests/Unit/Charset/CharsetTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit\Charset;
+
+use EdifactParser\Charset\Charset;
+use EdifactParser\EdifactParser;
+use EdifactParser\Segments\UNBInterchangeHeader;
+use PHPUnit\Framework\TestCase;
+
+final class CharsetTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function maps_syntax_identifiers_to_encodings(): void
+    {
+        self::assertSame('ISO-8859-1', Charset::encodingFor('UNOC'));
+        self::assertSame('ISO-8859-1', Charset::encodingFor('unoc')); // case-insensitive
+        self::assertSame('UTF-8', Charset::encodingFor('UNOY'));
+        self::assertSame('UTF-8', Charset::encodingFor('WHATEVER')); // unknown falls back to UTF-8
+    }
+
+    /**
+     * @test
+     */
+    public function decodes_latin1_bytes_to_utf8(): void
+    {
+        // 0xE9 is 'é' in ISO-8859-1; in UTF-8 it is the two bytes 0xC3 0xA9.
+        self::assertSame("\xC3\xA9", Charset::toUtf8("\xE9", 'UNOC'));
+
+        // UTF-8 input is returned unchanged.
+        self::assertSame("\xC3\xA9", Charset::toUtf8("\xC3\xA9", 'UNOY'));
+    }
+
+    /**
+     * @test
+     */
+    public function unb_exposes_its_character_encoding(): void
+    {
+        $unb = EdifactParser::createWithDefaultSegments()
+            ->parseFile(__DIR__ . '/../../../example/edifact-sample.edi')
+            ->globalSegments()
+            ->segmentByTagAndSubId('UNB', 'UNOC');
+
+        self::assertInstanceOf(UNBInterchangeHeader::class, $unb);
+        self::assertSame('ISO-8859-1', $unb->characterEncoding());
+    }
+}


### PR DESCRIPTION
Adds `Charset\Charset`: map a UNB syntax id (UNOA/UNOB→ASCII, UNOC→ISO-8859-1, …, UNOY→UTF-8) to an encoding and `toUtf8()` data values. `UNBInterchangeHeader::characterEncoding()` exposes the interchange encoding.

```php
$utf8 = Charset::toUtf8($nad->name(), $unb->syntaxIdentifier());
```

Adds an `ext-mbstring` requirement (present on CI; lock synced). Additive → 6.2.0. Gate green: psalm/phpstan/rector + 159 tests.