### PR TITLE
feat: typed FTX/LOC/TDT/IMD/PAC/GID segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.2.0] - 2026-07-22
 
 #### Added
+- **More typed segments** (registered by default): `FTX` (free text), `LOC` (place),
+  `TDT` (transport details), `IMD` (item description), `PAC` (package), `GID`
+  (goods item details), each with domain accessors.
 - **Character-set decoding** (`Charset\Charset`): map a UNB syntax identifier
   (UNOA/UNOB → ASCII, UNOC → ISO-8859-1, … UNOY → UTF-8) to an encoding and decode
   data values to UTF-8. `UNBInterchangeHeader::characterEncoding()` exposes the

--- a/src/Segments/FTXFreeText.php
+++ b/src/Segments/FTXFreeText.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class FTXFreeText extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'FTX';
+    }
+
+    /**
+     * Text subject qualifier (e.g., 'AAI' = General information, 'DEL' = Delivery)
+     */
+    public function subjectQualifier(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Free-text value (first component of the text literal element)
+     */
+    public function text(): string
+    {
+        return $this->firstComponent(4);
+    }
+}

--- a/src/Segments/GIDGoodsItemDetails.php
+++ b/src/Segments/GIDGoodsItemDetails.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class GIDGoodsItemDetails extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'GID';
+    }
+
+    /**
+     * Goods item number (sequence within the consignment)
+     */
+    public function goodsItemNumber(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Number of packages (first component of the number-and-type element)
+     */
+    public function numberOfPackages(): string
+    {
+        return $this->firstComponent(2);
+    }
+
+    /**
+     * Type of packages code, when present in the composite
+     */
+    public function packageTypeCode(): string
+    {
+        return $this->component(1, 2);
+    }
+}

--- a/src/Segments/IMDItemDescription.php
+++ b/src/Segments/IMDItemDescription.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class IMDItemDescription extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'IMD';
+    }
+
+    /**
+     * Description format code (e.g., 'A' = Free-form, 'C' = Code, 'F' = Free-form long)
+     */
+    public function descriptionFormatCode(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Item characteristic code (e.g., '35' = Colour, '38' = Size)
+     */
+    public function itemCharacteristicCode(): string
+    {
+        return $this->element(2);
+    }
+
+    /**
+     * Item description code (first component of the description element)
+     */
+    public function itemDescriptionCode(): string
+    {
+        return $this->firstComponent(3);
+    }
+
+    /**
+     * Free-form item description, when present in the composite
+     */
+    public function itemDescription(): string
+    {
+        return $this->component(3, 3);
+    }
+}

--- a/src/Segments/LOCPlace.php
+++ b/src/Segments/LOCPlace.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class LOCPlace extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'LOC';
+    }
+
+    /**
+     * Place/location qualifier (e.g., '5' = Place of departure, '8' = Place of destination)
+     */
+    public function locationQualifier(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Location identification (e.g., a UN/LOCODE)
+     */
+    public function locationId(): string
+    {
+        return $this->firstComponent(2);
+    }
+
+    /**
+     * Location name (free-form), when present in the composite
+     */
+    public function locationName(): string
+    {
+        return $this->component(3, 2);
+    }
+}

--- a/src/Segments/PACPackage.php
+++ b/src/Segments/PACPackage.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class PACPackage extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'PAC';
+    }
+
+    /**
+     * Number of packages
+     */
+    public function numberOfPackages(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Packaging type code (e.g., 'CT' = Carton, 'PX' = Pallet, 'BX' = Box)
+     */
+    public function packagingTypeCode(): string
+    {
+        return $this->firstComponent(3);
+    }
+}

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -37,6 +37,12 @@ final class SegmentFactory implements SegmentFactoryInterface
         'UNG' => UNGFunctionalGroupHeader::class,
         'UNE' => UNEFunctionalGroupTrailer::class,
         'UNZ' => UNZInterchangeTrailer::class,
+        'FTX' => FTXFreeText::class,
+        'LOC' => LOCPlace::class,
+        'TDT' => TDTTransportDetails::class,
+        'IMD' => IMDItemDescription::class,
+        'PAC' => PACPackage::class,
+        'GID' => GIDGoodsItemDetails::class,
     ];
 
     private const TAG_LENGTH = 3;

--- a/src/Segments/TDTTransportDetails.php
+++ b/src/Segments/TDTTransportDetails.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class TDTTransportDetails extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'TDT';
+    }
+
+    /**
+     * Transport stage qualifier (e.g., '20' = Main-carriage transport, '30' = On-carriage)
+     */
+    public function transportStageQualifier(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Means of transport journey / conveyance reference number
+     */
+    public function conveyanceReference(): string
+    {
+        return $this->element(2);
+    }
+
+    /**
+     * Mode of transport code (e.g., '10' = Maritime, '20' = Rail, '30' = Road, '40' = Air)
+     */
+    public function modeOfTransport(): string
+    {
+        return $this->firstComponent(3);
+    }
+
+    /**
+     * Carrier identification
+     */
+    public function carrierId(): string
+    {
+        return $this->firstComponent(5);
+    }
+}

--- a/tests/Unit/Segments/AdditionalSegmentsTest.php
+++ b/tests/Unit/Segments/AdditionalSegmentsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit\Segments;
+
+use EdifactParser\EdifactParser;
+use EdifactParser\Segments\FTXFreeText;
+use EdifactParser\Segments\GIDGoodsItemDetails;
+use EdifactParser\Segments\IMDItemDescription;
+use EdifactParser\Segments\LOCPlace;
+use EdifactParser\Segments\PACPackage;
+use EdifactParser\Segments\SegmentFactory;
+use EdifactParser\Segments\TDTTransportDetails;
+use PHPUnit\Framework\TestCase;
+
+final class AdditionalSegmentsTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider registeredTags
+     *
+     * @param class-string $class
+     */
+    public function factory_creates_typed_segments(string $tag, string $class): void
+    {
+        $segment = SegmentFactory::withDefaultSegments()->createSegmentFromArray([$tag, 'x']);
+
+        self::assertInstanceOf($class, $segment);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: class-string}>
+     */
+    public static function registeredTags(): array
+    {
+        return [
+            'FTX' => ['FTX', FTXFreeText::class],
+            'LOC' => ['LOC', LOCPlace::class],
+            'TDT' => ['TDT', TDTTransportDetails::class],
+            'IMD' => ['IMD', IMDItemDescription::class],
+            'PAC' => ['PAC', PACPackage::class],
+            'GID' => ['GID', GIDGoodsItemDetails::class],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function tdt_and_gid_accessors_from_the_sample(): void
+    {
+        $message = EdifactParser::createWithDefaultSegments()
+            ->parseFile(__DIR__ . '/../../../example/edifact-sample.edi')
+            ->transactionMessages()[0];
+
+        $tdt = $message->query()->withTag('TDT')->first();
+        self::assertInstanceOf(TDTTransportDetails::class, $tdt);
+        self::assertSame('20', $tdt->transportStageQualifier());
+
+        $gid = $message->query()->withTag('GID')->first();
+        self::assertInstanceOf(GIDGoodsItemDetails::class, $gid);
+        self::assertSame('1', $gid->goodsItemNumber());
+        self::assertSame('1', $gid->numberOfPackages());
+    }
+
+    /**
+     * @test
+     */
+    public function composite_accessors(): void
+    {
+        $ftx = new FTXFreeText(['FTX', 'AAI', '', '', 'Some free text']);
+        self::assertSame('AAI', $ftx->subjectQualifier());
+        self::assertSame('Some free text', $ftx->text());
+
+        $loc = new LOCPlace(['LOC', '5', ['DEHAM', '139', '6', 'Hamburg']]);
+        self::assertSame('5', $loc->locationQualifier());
+        self::assertSame('DEHAM', $loc->locationId());
+        self::assertSame('Hamburg', $loc->locationName());
+
+        $pac = new PACPackage(['PAC', '12', '', ['CT']]);
+        self::assertSame('12', $pac->numberOfPackages());
+        self::assertSame('CT', $pac->packagingTypeCode());
+
+        $imd = new IMDItemDescription(['IMD', 'F', '', ['', '', '', 'Blue shirt']]);
+        self::assertSame('F', $imd->descriptionFormatCode());
+        self::assertSame('Blue shirt', $imd->itemDescription());
+    }
+}


### PR DESCRIPTION
Broadens typed-segment coverage with six common segments (registered by default, with domain accessors): FTX (free text), LOC (place), TDT (transport details), IMD (item description), PAC (package), GID (goods item details). Additive → 6.2.0. Gate green: psalm/phpstan/rector + 167 tests.