### PR TITLE
feat: add SegmentFactory::withAdditionalSegments()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+#### Added
+- `SegmentFactory::withAdditionalSegments()` registers custom segments on top of
+  the defaults, so you no longer have to spread `DEFAULT_SEGMENTS` yourself. A
+  custom class under a default tag overrides that default.
+
 ## [6.2.1] - 2026-07-23
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -459,13 +459,16 @@ use EdifactParser\EdifactParser;
 use EdifactParser\Segments\SegmentFactory;
 use YourApp\Segments\EQDEquipmentDetails;
 
-$factory = SegmentFactory::withSegments([
-    ...SegmentFactory::DEFAULT_SEGMENTS, // keep the 26 built-ins
-    'EQD' => EQDEquipmentDetails::class, // add yours
+$factory = SegmentFactory::withAdditionalSegments([
+    'EQD' => EQDEquipmentDetails::class, // added on top of the 26 built-ins
 ]);
 
 $parser = new EdifactParser($factory);
 ```
+
+> `withAdditionalSegments()` keeps every default and merges your tags on top —
+> registering a custom class under a default tag overrides that default. Use
+> `withSegments()` instead when you want an explicit, closed set of segments.
 
 ### Custom grouping rules
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -509,8 +509,7 @@
 }
 
 <span class="tc">// Register alongside the 26 built-ins</span>
-<span class="tv">$factory</span> = SegmentFactory::<span class="tf">withSegments</span>([
-    ...SegmentFactory::<span class="tp">DEFAULT_SEGMENTS</span>,
+<span class="tv">$factory</span> = SegmentFactory::<span class="tf">withAdditionalSegments</span>([
     <span class="ts">'EQD'</span> =&gt; EQDEquipmentDetails::<span class="tk">class</span>,
 ]);</pre>
     </div>

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -85,6 +85,18 @@ final class SegmentFactory implements SegmentFactoryInterface
         return new self(self::DEFAULT_SEGMENTS);
     }
 
+    /**
+     * The default segments plus the given ones. A custom class registered under a
+     * default tag overrides the default. Use this to add custom segments without
+     * having to re-declare the whole default map.
+     *
+     * @param  array<string,string>  $segments
+     */
+    public static function withAdditionalSegments(array $segments): self
+    {
+        return new self($segments + self::DEFAULT_SEGMENTS);
+    }
+
     public function createSegmentFromArray(array $rawArray): SegmentInterface
     {
         $tag = $rawArray[0] ?? null;

--- a/tests/Unit/Segments/SegmentFactoryTest.php
+++ b/tests/Unit/Segments/SegmentFactoryTest.php
@@ -55,6 +55,34 @@ final class SegmentFactoryTest extends TestCase
     /**
      * @test
      */
+    public function with_additional_segments_keeps_defaults(): void
+    {
+        $factory = SegmentFactory::withAdditionalSegments([
+            'ZZZ' => UNHMessageHeader::class,
+        ]);
+
+        // custom tag is registered
+        self::assertInstanceOf(UNHMessageHeader::class, $factory->createSegmentFromArray(['ZZZ']));
+        // defaults are still there
+        self::assertInstanceOf(NADNameAddress::class, $factory->createSegmentFromArray(['NAD']));
+        self::assertInstanceOf(DTMDateTimePeriod::class, $factory->createSegmentFromArray(['DTM']));
+    }
+
+    /**
+     * @test
+     */
+    public function with_additional_segments_overrides_a_default(): void
+    {
+        $factory = SegmentFactory::withAdditionalSegments([
+            'NAD' => UNHMessageHeader::class,
+        ]);
+
+        self::assertInstanceOf(UNHMessageHeader::class, $factory->createSegmentFromArray(['NAD']));
+    }
+
+    /**
+     * @test
+     */
     public function exception_when_tag_too_large(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Why

Extending the parser with a custom segment currently forces you to spread the whole default map:

```php
SegmentFactory::withSegments([
    ...SegmentFactory::DEFAULT_SEGMENTS,
    'EQD' => EQDEquipmentDetails::class,
]);
```

Easy to forget the spread → your custom factory silently drops the 26 built-ins. This was the main friction point in the extension API.

## What

New `SegmentFactory::withAdditionalSegments()` — merges your tags on top of the defaults:

```php
SegmentFactory::withAdditionalSegments([
    'EQD' => EQDEquipmentDetails::class,
]);
```

- Keeps every default, adds yours.
- A custom class under a default tag overrides that default.
- `withSegments()` unchanged for an explicit, closed set.

## Tests / docs

- 2 new unit tests (keeps defaults; overrides a default).
- README extend example + docs landing page updated to the cleaner helper.
- CHANGELOG `[Unreleased]` entry.
- Full quality gate green (cs-fixer, phpstan, rector, 169 tests).