### PR TITLE
feat: enrich thin default segments with typed accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SegmentFactory::withAdditionalSegments()` registers custom segments on top of
   the defaults, so you no longer have to spread `DEFAULT_SEGMENTS` yourself. A
   custom class under a default tag overrides that default.
+- Typed accessors for previously raw-only default segments:
+  - `CNTControl`: `controlQualifier()`, `controlValue()`, `measureUnit()`.
+  - `CUXCurrencyDetails`: `usageQualifier()`, `currencyCode()`, `rateQualifier()`.
+  - `MEADimensions`: `measurementPurpose()`, `measuredAttribute()`, `unitCode()`, `value()`.
+  - `PCIPackageId`: `markingInstructionsCode()`, `marksAndLabels()`.
+  - `PIAAdditionalProductId`: `productIdFunctionQualifier()`, `itemNumber()`, `itemTypeCode()`.
 
 ## [6.2.1] - 2026-07-23
 

--- a/src/Segments/CNTControl.php
+++ b/src/Segments/CNTControl.php
@@ -16,4 +16,29 @@ final class CNTControl extends AbstractSegment
     {
         return $this->requiredSubId();
     }
+
+    /**
+     * Control total type code qualifier (C270/6069), e.g. '2' = number of line
+     * items, '7' = gross weight.
+     */
+    public function controlQualifier(): string
+    {
+        return $this->component(0);
+    }
+
+    /**
+     * Control value (C270/6066): CNT+7:0.62:KGM -> '0.62'.
+     */
+    public function controlValue(): string
+    {
+        return $this->component(1);
+    }
+
+    /**
+     * Measure unit code when present (C270/6411): CNT+7:0.62:KGM -> 'KGM'.
+     */
+    public function measureUnit(): string
+    {
+        return $this->component(2);
+    }
 }

--- a/src/Segments/CUXCurrencyDetails.php
+++ b/src/Segments/CUXCurrencyDetails.php
@@ -16,4 +16,29 @@ final class CUXCurrencyDetails extends AbstractSegment
     {
         return $this->requiredSubId();
     }
+
+    /**
+     * Currency usage qualifier (C504/6347), e.g. '2' = reference currency,
+     * '3' = target currency.
+     */
+    public function usageQualifier(): string
+    {
+        return $this->component(0);
+    }
+
+    /**
+     * Currency code, ISO 4217 (C504/6345): CUX+2:EUR:4 -> 'EUR'.
+     */
+    public function currencyCode(): string
+    {
+        return $this->component(1);
+    }
+
+    /**
+     * Currency type/rate qualifier (C504/6343): CUX+2:EUR:4 -> '4'.
+     */
+    public function rateQualifier(): string
+    {
+        return $this->component(2);
+    }
 }

--- a/src/Segments/MEADimensions.php
+++ b/src/Segments/MEADimensions.php
@@ -11,4 +11,37 @@ final class MEADimensions extends AbstractSegment
     {
         return 'MEA';
     }
+
+    /**
+     * Measurement purpose qualifier (6311), e.g. 'WT' = weight, 'VOL' = volume.
+     */
+    public function measurementPurpose(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Measured attribute code (C502/6313), e.g. 'G' = gross. Empty when omitted:
+     * MEA+VOL++MTQ:0 -> ''.
+     */
+    public function measuredAttribute(): string
+    {
+        return $this->element(2);
+    }
+
+    /**
+     * Measurement unit code (C174/6411): MEA+WT+G+KGM:0.62 -> 'KGM'.
+     */
+    public function unitCode(): string
+    {
+        return $this->component(0, 3);
+    }
+
+    /**
+     * Measurement value (C174/6314): MEA+WT+G+KGM:0.62 -> '0.62'.
+     */
+    public function value(): string
+    {
+        return $this->component(1, 3);
+    }
 }

--- a/src/Segments/PCIPackageId.php
+++ b/src/Segments/PCIPackageId.php
@@ -11,4 +11,21 @@ final class PCIPackageId extends AbstractSegment
     {
         return 'PCI';
     }
+
+    /**
+     * Marking instructions code (4233): PCI+18+05055700896 -> '18'.
+     */
+    public function markingInstructionsCode(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Shipping marks / first marks-and-labels value (C210/7102):
+     * PCI+18+05055700896 -> '05055700896'.
+     */
+    public function marksAndLabels(): string
+    {
+        return $this->firstComponent(2);
+    }
 }

--- a/src/Segments/PIAAdditionalProductId.php
+++ b/src/Segments/PIAAdditionalProductId.php
@@ -11,4 +11,30 @@ final class PIAAdditionalProductId extends AbstractSegment
     {
         return 'PIA';
     }
+
+    /**
+     * Product id function qualifier (4347), e.g. '1' = additional identification,
+     * '5' = product identification.
+     */
+    public function productIdFunctionQualifier(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Item number (C212/7140): PIA+5+ABC123:SA -> 'ABC123'.
+     */
+    public function itemNumber(): string
+    {
+        return $this->firstComponent(2);
+    }
+
+    /**
+     * Item number type code (C212/7143): PIA+5+ABC123:SA -> 'SA' (EAN, buyer's
+     * article number, etc.).
+     */
+    public function itemTypeCode(): string
+    {
+        return $this->component(1, 2);
+    }
 }

--- a/tests/Unit/Segments/CNTControlTest.php
+++ b/tests/Unit/Segments/CNTControlTest.php
@@ -26,6 +26,30 @@ final class CNTControlTest extends TestCase
     /**
      * @test
      */
+    public function typed_accessors(): void
+    {
+        $segment = new CNTControl(['CNT', ['7', '0.62', 'KGM']]);
+
+        self::assertSame('7', $segment->controlQualifier());
+        self::assertSame('0.62', $segment->controlValue());
+        self::assertSame('KGM', $segment->measureUnit());
+    }
+
+    /**
+     * @test
+     */
+    public function measure_unit_is_empty_when_absent(): void
+    {
+        $segment = new CNTControl(['CNT', ['2', '2']]);
+
+        self::assertSame('2', $segment->controlQualifier());
+        self::assertSame('2', $segment->controlValue());
+        self::assertSame('', $segment->measureUnit());
+    }
+
+    /**
+     * @test
+     */
     public function missing_sub_id(): void
     {
         $segment = new CNTControl(['CNT']);

--- a/tests/Unit/Segments/CUXCurrencyDetailsTest.php
+++ b/tests/Unit/Segments/CUXCurrencyDetailsTest.php
@@ -21,4 +21,16 @@ class CUXCurrencyDetailsTest extends TestCase
         self::assertEquals('5', $segment->subId());
         self::assertEquals($rawValues, $segment->rawValues());
     }
+
+    /**
+     * @test
+     */
+    public function typed_accessors(): void
+    {
+        $segment = new CUXCurrencyDetails(['CUX', ['2', 'EUR', '4']]);
+
+        self::assertSame('2', $segment->usageQualifier());
+        self::assertSame('EUR', $segment->currencyCode());
+        self::assertSame('4', $segment->rateQualifier());
+    }
 }

--- a/tests/Unit/Segments/MEADimensionsTest.php
+++ b/tests/Unit/Segments/MEADimensionsTest.php
@@ -21,4 +21,30 @@ final class MEADimensionsTest extends TestCase
         self::assertEquals('WT', $segment->subId());
         self::assertEquals($rawValues, $segment->rawValues());
     }
+
+    /**
+     * @test
+     */
+    public function typed_accessors(): void
+    {
+        $segment = new MEADimensions(['MEA', 'WT', 'G', ['KGM', '0.62']]);
+
+        self::assertSame('WT', $segment->measurementPurpose());
+        self::assertSame('G', $segment->measuredAttribute());
+        self::assertSame('KGM', $segment->unitCode());
+        self::assertSame('0.62', $segment->value());
+    }
+
+    /**
+     * @test
+     */
+    public function measured_attribute_is_empty_when_omitted(): void
+    {
+        $segment = new MEADimensions(['MEA', 'VOL', '', ['MTQ', '0']]);
+
+        self::assertSame('VOL', $segment->measurementPurpose());
+        self::assertSame('', $segment->measuredAttribute());
+        self::assertSame('MTQ', $segment->unitCode());
+        self::assertSame('0', $segment->value());
+    }
 }

--- a/tests/Unit/Segments/PCIPackageIdTest.php
+++ b/tests/Unit/Segments/PCIPackageIdTest.php
@@ -21,4 +21,15 @@ final class PCIPackageIdTest extends TestCase
         self::assertEquals('18', $segment->subId());
         self::assertEquals($rawValues, $segment->rawValues());
     }
+
+    /**
+     * @test
+     */
+    public function typed_accessors(): void
+    {
+        $segment = new PCIPackageId(['PCI', '18', '05055700896']);
+
+        self::assertSame('18', $segment->markingInstructionsCode());
+        self::assertSame('05055700896', $segment->marksAndLabels());
+    }
 }

--- a/tests/Unit/Segments/PIAAdditionalProductIdTest.php
+++ b/tests/Unit/Segments/PIAAdditionalProductIdTest.php
@@ -21,4 +21,16 @@ class PIAAdditionalProductIdTest extends TestCase
         self::assertEquals('22', $segment->subId());
         self::assertEquals($rawValues, $segment->rawValues());
     }
+
+    /**
+     * @test
+     */
+    public function typed_accessors(): void
+    {
+        $segment = new PIAAdditionalProductId(['PIA', '5', ['ABC123', 'SA']]);
+
+        self::assertSame('5', $segment->productIdFunctionQualifier());
+        self::assertSame('ABC123', $segment->itemNumber());
+        self::assertSame('SA', $segment->itemTypeCode());
+    }
 }


### PR DESCRIPTION
## Why

Five default segments were raw-only — `tag()` + `rawValues()`, nothing else. Reading a control total or a currency meant index-digging by hand. Making the default factory *richer where it's safe* is the low-risk half of the "richer defaults" work (breadth/version-specific accessors stay behind the factory override).

## What

Typed, version-stable accessors added:

| Segment | Accessors |
|---|---|
| `CNTControl` | `controlQualifier()`, `controlValue()`, `measureUnit()` |
| `CUXCurrencyDetails` | `usageQualifier()`, `currencyCode()`, `rateQualifier()` |
| `MEADimensions` | `measurementPurpose()`, `measuredAttribute()`, `unitCode()`, `value()` |
| `PCIPackageId` | `markingInstructionsCode()`, `marksAndLabels()` |
| `PIAAdditionalProductId` | `productIdFunctionQualifier()`, `itemNumber()`, `itemTypeCode()` |

Only elements whose meaning is stable across the common directories are typed; anything version-sensitive stays reachable via `rawValues()`/`element()` and the factory override. Element positions verified against the real shapes in `example/edifact-sample.edi` (`CNT+7:0.62:KGM`, `CUX+2:EUR:4`, `MEA+WT+G+KGM:0.62`, `PCI+18+05055700896`).

## Tests / docs

- Enriched the 5 existing segment tests with typed-accessor cases (incl. empty/omitted-component edge cases). 176 tests, 508 assertions green.
- Full quality gate green: cs-fixer, phpstan, rector.
- CHANGELOG `[Unreleased]` updated.