### PR TITLE
feat: add CTA, COM, TAX, PCD, PAT, TOD to default segments (26 → 32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SegmentFactory::withAdditionalSegments()` registers custom segments on top of
   the defaults, so you no longer have to spread `DEFAULT_SEGMENTS` yourself. A
   custom class under a default tag overrides that default.
+- Six new default segments, typed and registered out of the box (26 -> 32):
+  `CTA` (contact), `COM` (communication), `TAX` (duty/tax/fee), `PCD`
+  (percentage), `PAT` (payment terms), `TOD` (terms of delivery). Only
+  version-stable elements are typed; the factory override remains the path for
+  dialect-specific accessors.
 - Typed accessors for previously raw-only default segments:
   - `CNTControl`: `controlQualifier()`, `controlValue()`, `measureUnit()`.
   - `CUXCurrencyDetails`: `usageQualifier()`, `currencyCode()`, `rateQualifier()`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ interchanges with a typed, object-oriented API.
 - 🌊 **Stream** — parse multi-gigabyte files in bounded memory (one message at a time).
 - 🧱 **Model the full envelope** — interchange → functional groups (`UNG/UNE`) → messages,
   with duplicate-preserving access and typed metadata on every envelope segment.
-- 🏷️ **26 typed segments** out of the box with domain accessors, plus qualifier constants —
+- 🏷️ **32 typed segments** out of the box with domain accessors, plus qualifier constants —
   and trivially [extensible](#-extending) with your own.
 - 🔎 **Fluent query API** and a **statistics analyzer** for extracting data.
 - 🌍 **Charset-aware** (`UNOA`…`UNOY`), **strictly typed** (PHP 8.0+, PSR-4), and fully
@@ -315,10 +315,11 @@ $name = Charset::toUtf8($nad->name(), $unb->syntaxIdentifier());
 
 ### Built-in segments
 
-26 segments are typed and registered by default:
+32 segments are typed and registered by default:
 
 - **Envelope / service:** `UNB`, `UNG`, `UNH`, `UNS`, `UNT`, `UNE`, `UNZ`
 - **Header:** `BGM`, `DTM`, `RFF`, `NAD`, `CUX`, `TDT`, `LOC`, `FTX`
+- **Party / terms:** `CTA`, `COM`, `PAT`, `PCD`, `TAX`, `TOD`
 - **Detail / summary:** `LIN`, `PIA`, `IMD`, `QTY`, `PRI`, `MEA`, `PAC`, `GID`, `MOA`, `PCI`, `CNT`
 
 Any other tag parses as an `UnknownSegment` (readable via `rawValues()`); add your own typed
@@ -460,7 +461,7 @@ use EdifactParser\Segments\SegmentFactory;
 use YourApp\Segments\EQDEquipmentDetails;
 
 $factory = SegmentFactory::withAdditionalSegments([
-    'EQD' => EQDEquipmentDetails::class, // added on top of the 26 built-ins
+    'EQD' => EQDEquipmentDetails::class, // added on top of the 32 built-ins
 ]);
 
 $parser = new EdifactParser($factory);

--- a/docs/index.html
+++ b/docs/index.html
@@ -395,7 +395,7 @@
       <div class="pillar"><div class="ic">✅</div><h3>Validate</h3><p>Pluggable rule sets for required segments, cardinality and relative order. Ready-made sets for ORDERS, INVOIC, DESADV, IFTMIN.</p></div>
       <div class="pillar"><div class="ic">🌊</div><h3>Stream</h3><p>Parse multi-gigabyte files in bounded memory — one message at a time, honouring a leading <code>UNA</code> service advice.</p></div>
       <div class="pillar"><div class="ic">🧱</div><h3>Full envelope model</h3><p>Interchange → groups → messages, with duplicate-preserving access and typed metadata on every envelope segment.</p></div>
-      <div class="pillar"><div class="ic">🏷️</div><h3>26 typed segments</h3><p>Domain accessors and qualifier constants out of the box — and trivially extensible with your own segment classes.</p></div>
+      <div class="pillar"><div class="ic">🏷️</div><h3>32 typed segments</h3><p>Domain accessors and qualifier constants out of the box — and trivially extensible with your own segment classes.</p></div>
       <div class="pillar"><div class="ic">🔎</div><h3>Fluent query API</h3><p>Chain filters, transforms and pagination over every segment; a statistics analyzer aggregates counts and totals.</p></div>
       <div class="pillar"><div class="ic">🌍</div><h3>Charset-aware</h3><p><code>UNOA</code>…<code>UNOY</code> decoding to UTF-8, strict types, PSR-4, fully covered by PHPUnit, PHPStan, Psalm &amp; Rector.</p></div>
     </div>
@@ -508,7 +508,7 @@
     }
 }
 
-<span class="tc">// Register alongside the 26 built-ins</span>
+<span class="tc">// Register alongside the 32 built-ins</span>
 <span class="tv">$factory</span> = SegmentFactory::<span class="tf">withAdditionalSegments</span>([
     <span class="ts">'EQD'</span> =&gt; EQDEquipmentDetails::<span class="tk">class</span>,
 ]);</pre>
@@ -520,7 +520,7 @@
 <section class="alt">
   <div class="wrap">
     <p class="eyebrow">Batteries included</p>
-    <h2 class="sec-title">26 typed segments out of the box</h2>
+    <h2 class="sec-title">32 typed segments out of the box</h2>
     <p class="sec-sub">Each with domain accessors. Any other tag parses as an <code>UnknownSegment</code>
       you can still read — then add a typed class in a few lines.</p>
     <div class="seg-groups">
@@ -531,6 +531,10 @@
       <div class="seg-group">
         <h4>Header</h4>
         <div class="chips"><span class="chip">BGM</span><span class="chip">DTM</span><span class="chip">RFF</span><span class="chip">NAD</span><span class="chip">CUX</span><span class="chip">TDT</span><span class="chip">LOC</span><span class="chip">FTX</span></div>
+      </div>
+      <div class="seg-group">
+        <h4>Party / terms</h4>
+        <div class="chips"><span class="chip">CTA</span><span class="chip">COM</span><span class="chip">PAT</span><span class="chip">PCD</span><span class="chip">TAX</span><span class="chip">TOD</span></div>
       </div>
       <div class="seg-group">
         <h4>Detail / summary</h4>

--- a/src/Segments/COMCommunicationContact.php
+++ b/src/Segments/COMCommunicationContact.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class COMCommunicationContact extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'COM';
+    }
+
+    /**
+     * Communication number or address (C076/3148):
+     * COM+john@acme.com:EM -> 'john@acme.com'.
+     */
+    public function communicationNumber(): string
+    {
+        return $this->component(0);
+    }
+
+    /**
+     * Communication channel qualifier (C076/3155), e.g. 'EM' = email,
+     * 'TE' = telephone, 'FX' = fax.
+     */
+    public function channelQualifier(): string
+    {
+        return $this->component(1);
+    }
+}

--- a/src/Segments/CTAContactInformation.php
+++ b/src/Segments/CTAContactInformation.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class CTAContactInformation extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'CTA';
+    }
+
+    /**
+     * Contact function code (3139), e.g. 'IC' = information contact,
+     * 'PD' = purchasing dept.
+     */
+    public function contactFunction(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Department or employee identification (C056/3413):
+     * CTA+IC+00001:John Smith -> '00001'.
+     */
+    public function contactId(): string
+    {
+        return $this->component(0, 2);
+    }
+
+    /**
+     * Department or employee name (C056/3412):
+     * CTA+IC+00001:John Smith -> 'John Smith'.
+     */
+    public function contactName(): string
+    {
+        return $this->component(1, 2);
+    }
+}

--- a/src/Segments/PATPaymentTerms.php
+++ b/src/Segments/PATPaymentTerms.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class PATPaymentTerms extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'PAT';
+    }
+
+    /**
+     * Payment terms type qualifier (4279), e.g. '1' = basic,
+     * '3' = discount.
+     */
+    public function typeQualifier(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Payment terms identification (C110/4277): PAT+1+3 -> '3'.
+     */
+    public function termsId(): string
+    {
+        return $this->firstComponent(2);
+    }
+}

--- a/src/Segments/PCDPercentageDetails.php
+++ b/src/Segments/PCDPercentageDetails.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class PCDPercentageDetails extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'PCD';
+    }
+
+    /**
+     * Percentage qualifier (C501/5245), e.g. '1' = allowance,
+     * '2' = charge, '3' = discount.
+     */
+    public function percentageQualifier(): string
+    {
+        return $this->component(0);
+    }
+
+    /**
+     * Percentage value (C501/5482): PCD+1:10 -> '10'.
+     */
+    public function percentage(): string
+    {
+        return $this->component(1);
+    }
+}

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -43,6 +43,12 @@ final class SegmentFactory implements SegmentFactoryInterface
         'IMD' => IMDItemDescription::class,
         'PAC' => PACPackage::class,
         'GID' => GIDGoodsItemDetails::class,
+        'CTA' => CTAContactInformation::class,
+        'COM' => COMCommunicationContact::class,
+        'TAX' => TAXDutyTaxFee::class,
+        'PCD' => PCDPercentageDetails::class,
+        'PAT' => PATPaymentTerms::class,
+        'TOD' => TODTermsOfDelivery::class,
     ];
 
     private const TAG_LENGTH = 3;

--- a/src/Segments/TAXDutyTaxFee.php
+++ b/src/Segments/TAXDutyTaxFee.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class TAXDutyTaxFee extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'TAX';
+    }
+
+    /**
+     * Duty/tax/fee function qualifier (5283), e.g. '7' = tax.
+     */
+    public function functionQualifier(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Duty/tax/fee type code (C241/5153): TAX+7+VAT+++:::19+S -> 'VAT'.
+     */
+    public function typeCode(): string
+    {
+        return $this->firstComponent(2);
+    }
+
+    /**
+     * Duty/tax/fee rate (C243/5278): TAX+7+VAT+++:::19+S -> '19'.
+     */
+    public function rate(): string
+    {
+        return $this->component(3, 5);
+    }
+
+    /**
+     * Duty/tax/fee category code (5305), e.g. 'S' = standard rate,
+     * 'Z' = zero rated.
+     */
+    public function categoryCode(): string
+    {
+        return $this->element(6);
+    }
+}

--- a/src/Segments/TODTermsOfDelivery.php
+++ b/src/Segments/TODTermsOfDelivery.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+/** @psalm-immutable */
+final class TODTermsOfDelivery extends AbstractSegment
+{
+    public function tag(): string
+    {
+        return 'TOD';
+    }
+
+    /**
+     * Delivery or transport terms function code (4055), e.g. '6' = terms of
+     * delivery.
+     */
+    public function functionCode(): string
+    {
+        return $this->element(1);
+    }
+
+    /**
+     * Transport charges method of payment (4215), e.g. 'CC' = collect,
+     * 'PP' = prepaid.
+     */
+    public function transportChargesMethod(): string
+    {
+        return $this->element(2);
+    }
+
+    /**
+     * Delivery terms code, e.g. Incoterm (C100/4053):
+     * TOD+6++CIF -> 'CIF'.
+     */
+    public function termsCode(): string
+    {
+        return $this->firstComponent(3);
+    }
+}

--- a/tests/Unit/Segments/AdditionalSegmentsTest.php
+++ b/tests/Unit/Segments/AdditionalSegmentsTest.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace EdifactParser\Tests\Unit\Segments;
 
 use EdifactParser\EdifactParser;
+use EdifactParser\Segments\COMCommunicationContact;
+use EdifactParser\Segments\CTAContactInformation;
 use EdifactParser\Segments\FTXFreeText;
 use EdifactParser\Segments\GIDGoodsItemDetails;
 use EdifactParser\Segments\IMDItemDescription;
 use EdifactParser\Segments\LOCPlace;
 use EdifactParser\Segments\PACPackage;
+use EdifactParser\Segments\PATPaymentTerms;
+use EdifactParser\Segments\PCDPercentageDetails;
 use EdifactParser\Segments\SegmentFactory;
+use EdifactParser\Segments\TAXDutyTaxFee;
 use EdifactParser\Segments\TDTTransportDetails;
+use EdifactParser\Segments\TODTermsOfDelivery;
 use PHPUnit\Framework\TestCase;
 
 final class AdditionalSegmentsTest extends TestCase
@@ -42,7 +48,47 @@ final class AdditionalSegmentsTest extends TestCase
             'IMD' => ['IMD', IMDItemDescription::class],
             'PAC' => ['PAC', PACPackage::class],
             'GID' => ['GID', GIDGoodsItemDetails::class],
+            'CTA' => ['CTA', CTAContactInformation::class],
+            'COM' => ['COM', COMCommunicationContact::class],
+            'TAX' => ['TAX', TAXDutyTaxFee::class],
+            'PCD' => ['PCD', PCDPercentageDetails::class],
+            'PAT' => ['PAT', PATPaymentTerms::class],
+            'TOD' => ['TOD', TODTermsOfDelivery::class],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function party_and_terms_accessors(): void
+    {
+        $cta = new CTAContactInformation(['CTA', 'IC', ['00001', 'John Smith']]);
+        self::assertSame('IC', $cta->contactFunction());
+        self::assertSame('00001', $cta->contactId());
+        self::assertSame('John Smith', $cta->contactName());
+
+        $com = new COMCommunicationContact(['COM', ['john@acme.com', 'EM']]);
+        self::assertSame('john@acme.com', $com->communicationNumber());
+        self::assertSame('EM', $com->channelQualifier());
+
+        $tax = new TAXDutyTaxFee(['TAX', '7', ['VAT'], '', '', ['', '', '', '19'], 'S']);
+        self::assertSame('7', $tax->functionQualifier());
+        self::assertSame('VAT', $tax->typeCode());
+        self::assertSame('19', $tax->rate());
+        self::assertSame('S', $tax->categoryCode());
+
+        $pcd = new PCDPercentageDetails(['PCD', ['1', '10']]);
+        self::assertSame('1', $pcd->percentageQualifier());
+        self::assertSame('10', $pcd->percentage());
+
+        $pat = new PATPaymentTerms(['PAT', '1', ['3']]);
+        self::assertSame('1', $pat->typeQualifier());
+        self::assertSame('3', $pat->termsId());
+
+        $tod = new TODTermsOfDelivery(['TOD', '6', '', ['CIF', '', '', 'Cost Insurance Freight']]);
+        self::assertSame('6', $tod->functionCode());
+        self::assertSame('', $tod->transportChargesMethod());
+        self::assertSame('CIF', $tod->termsCode());
     }
 
     /**

--- a/tests/Unit/TransactionMessageTest.php
+++ b/tests/Unit/TransactionMessageTest.php
@@ -10,12 +10,12 @@ use EdifactParser\LineItem;
 use EdifactParser\ParserResult;
 use EdifactParser\SegmentList;
 use EdifactParser\Segments\CNTControl;
+use EdifactParser\Segments\COMCommunicationContact;
 use EdifactParser\Segments\LINLineItem;
 use EdifactParser\Segments\NADNameAddress;
 use EdifactParser\Segments\QTYQuantity;
 use EdifactParser\Segments\UNBInterchangeHeader;
 use EdifactParser\Segments\UNHMessageHeader;
-use EdifactParser\Segments\UnknownSegment;
 use EdifactParser\Segments\UNTMessageFooter;
 use EdifactParser\Segments\UNZInterchangeTrailer;
 use EdifactParser\TransactionMessage;
@@ -407,7 +407,7 @@ EDI;
         $expected = [
             new ContextSegment(
                 new NADNameAddress(['NAD', 'CN']),
-                [new UnknownSegment(['COM', ['123', 'TE']])],
+                [new COMCommunicationContact(['COM', ['123', 'TE']])],
             ),
             new ContextSegment(
                 new LINLineItem(['LIN', '1']),
@@ -420,7 +420,7 @@ EDI;
         $nadContext = $firstMessage->segmentByTagAndSubId('NAD', 'CN');
         self::assertInstanceOf(ContextSegment::class, $nadContext);
         self::assertEquals([
-            new UnknownSegment(['COM', ['123', 'TE']]),
+            new COMCommunicationContact(['COM', ['123', 'TE']]),
         ], $nadContext->children());
 
         $linContext = $firstMessage->segmentByTagAndSubId('LIN', '1');


### PR DESCRIPTION
## Why

Richer defaults where it's safe. Six of the most common party/terms segments were raw-only (`UnknownSegment`), so reading a contact email, a VAT rate or an Incoterm meant index-digging. These appear across ORDERS / INVOIC / DESADV / IFTMIN.

Deliberately curated, not exhaustive — quality over count. `EQD` stays out of the defaults on purpose: it's the "add your own segment" teaching example in the README/docs.

## What

| Tag | Segment | Typed accessors |
|---|---|---|
| `CTA` | Contact information | `contactFunction()`, `contactId()`, `contactName()` |
| `COM` | Communication contact | `communicationNumber()`, `channelQualifier()` |
| `TAX` | Duty/tax/fee | `functionQualifier()`, `typeCode()`, `rate()`, `categoryCode()` |
| `PCD` | Percentage details | `percentageQualifier()`, `percentage()` |
| `PAT` | Payment terms | `typeQualifier()`, `termsId()` |
| `TOD` | Terms of delivery | `functionCode()`, `transportChargesMethod()`, `termsCode()` |

Only version-stable elements are typed. Anything dialect-sensitive stays reachable via `rawValues()`/`element()` and the factory override (`withSegments()` / `withAdditionalSegments()`) — unchanged.

## Notes

- One existing test (`test_context_segments`) used `COM` as its "unknown child" example; `COM` is now a real typed child (it's already in the default `childTags`), so the expectation was updated to `COMCommunicationContact`. Unknown-segment behaviour is still covered by `UnknownSegmentTest`.

## Tests / docs

- New factory registration cases + a `party_and_terms_accessors` test (incl. omitted-component edge cases). 183 tests, 530 assertions green.
- Full quality gate green: cs-fixer, phpstan, rector.
- README segment list + landing page grid + counts updated 26 → 32. CHANGELOG `[Unreleased]` updated.