### PR TITLE
chore: release 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.3.0] - 2026-07-24
+
 #### Added
 - `SegmentFactory::withAdditionalSegments()` registers custom segments on top of
   the defaults, so you no longer have to spread `DEFAULT_SEGMENTS` yourself. A


### PR DESCRIPTION
Release **6.3.0** — richer default segments, a friendlier factory, and 100% test coverage.

### Added
- `SegmentFactory::withAdditionalSegments()` — register custom segments on top of the defaults.
- Six new default segments (26 → 32): `CTA`, `COM`, `TAX`, `PCD`, `PAT`, `TOD`.
- Typed accessors for previously raw-only segments: `CNT`, `CUX`, `MEA`, `PCI`, `PIA`.

### Changed
- `SegmentFactory` rejects a non-existent segment class with a clean `InvalidArgumentException` (no PHP warning).
- `EdifactParser::parseFile()` no longer emits a warning on an unreadable file.

### Tests
- **100% line/method/class coverage**, enforced by a new CI gate.

Backward-compatible (minor bump from 6.2.1).