### PR TITLE
feat: composable ENVELOPE_SEGMENTS / BUSINESS_SEGMENTS bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Added
+- Composable segment bundles on `SegmentFactory`: `ENVELOPE_SEGMENTS` (the UN*
+  service/control segments) and `BUSINESS_SEGMENTS` (header/party/detail/summary).
+  `DEFAULT_SEGMENTS` is now their union, so you can build a lean factory with, for
+  example, `withSegments(SegmentFactory::ENVELOPE_SEGMENTS + ['NAD' => ...])`.
+
 ## [6.3.0] - 2026-07-24
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -471,6 +471,26 @@ $parser = new EdifactParser($factory);
 > registering a custom class under a default tag overrides that default. Use
 > `withSegments()` instead when you want an explicit, closed set of segments.
 
+### Composable segment bundles
+
+The defaults are exposed as two composable bundles so you can build a lean factory
+that only types the tags you care about — everything else still parses as a readable
+`UnknownSegment`:
+
+- `SegmentFactory::ENVELOPE_SEGMENTS` — the UN* service/control segments (7).
+- `SegmentFactory::BUSINESS_SEGMENTS` — header, party/terms, detail and summary (25).
+- `SegmentFactory::DEFAULT_SEGMENTS` — the union of both (32).
+
+```php
+// Envelope structure + just the segments you extract:
+$factory = SegmentFactory::withSegments(
+    SegmentFactory::ENVELOPE_SEGMENTS + [
+        'NAD' => NADNameAddress::class,
+        'LIN' => LINLineItem::class,
+    ],
+);
+```
+
 ### Custom grouping rules
 
 Context hierarchies and line-item boundaries are driven by `GroupingRules`. Pass a

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -15,41 +15,64 @@ use function strlen;
 /** @psalm-immutable */
 final class SegmentFactory implements SegmentFactoryInterface
 {
-    /** @var array<string,string> */
-    public const DEFAULT_SEGMENTS = [
-        'UNH' => UNHMessageHeader::class,
+    /**
+     * Service/control segments that frame every interchange (the UN* envelope).
+     * Compose them with your own tags for a lean parser that still understands the
+     * interchange structure, e.g. `withSegments(ENVELOPE_SEGMENTS + ['NAD' => ...])`.
+     *
+     * @var array<string,string>
+     */
+    public const ENVELOPE_SEGMENTS = [
         'UNB' => UNBInterchangeHeader::class,
-        'BGM' => BGMBeginningOfMessage::class,
-        'DTM' => DTMDateTimePeriod::class,
-        'NAD' => NADNameAddress::class,
-        'MEA' => MEADimensions::class,
-        'CNT' => CNTControl::class,
-        'PCI' => PCIPackageId::class,
-        'UNT' => UNTMessageFooter::class,
-        'RFF' => RFFReference::class,
-        'CUX' => CUXCurrencyDetails::class,
-        'LIN' => LINLineItem::class,
-        'QTY' => QTYQuantity::class,
-        'PRI' => PRIPrice::class,
-        'PIA' => PIAAdditionalProductId::class,
-        'UNS' => UNSSectionControl::class,
-        'MOA' => MOAMonetaryAmount::class,
         'UNG' => UNGFunctionalGroupHeader::class,
+        'UNH' => UNHMessageHeader::class,
+        'UNS' => UNSSectionControl::class,
+        'UNT' => UNTMessageFooter::class,
         'UNE' => UNEFunctionalGroupTrailer::class,
         'UNZ' => UNZInterchangeTrailer::class,
-        'FTX' => FTXFreeText::class,
-        'LOC' => LOCPlace::class,
-        'TDT' => TDTTransportDetails::class,
-        'IMD' => IMDItemDescription::class,
-        'PAC' => PACPackage::class,
-        'GID' => GIDGoodsItemDetails::class,
+    ];
+
+    /**
+     * The business-content segments (header, party/terms, detail and summary) carried
+     * inside the envelope. Compose with {@see ENVELOPE_SEGMENTS} for a full parser.
+     *
+     * @var array<string,string>
+     */
+    public const BUSINESS_SEGMENTS = [
+        'BGM' => BGMBeginningOfMessage::class,
+        'DTM' => DTMDateTimePeriod::class,
+        'RFF' => RFFReference::class,
+        'NAD' => NADNameAddress::class,
         'CTA' => CTAContactInformation::class,
         'COM' => COMCommunicationContact::class,
-        'TAX' => TAXDutyTaxFee::class,
-        'PCD' => PCDPercentageDetails::class,
+        'CUX' => CUXCurrencyDetails::class,
         'PAT' => PATPaymentTerms::class,
+        'PCD' => PCDPercentageDetails::class,
+        'TAX' => TAXDutyTaxFee::class,
         'TOD' => TODTermsOfDelivery::class,
+        'TDT' => TDTTransportDetails::class,
+        'LOC' => LOCPlace::class,
+        'FTX' => FTXFreeText::class,
+        'LIN' => LINLineItem::class,
+        'PIA' => PIAAdditionalProductId::class,
+        'IMD' => IMDItemDescription::class,
+        'QTY' => QTYQuantity::class,
+        'PRI' => PRIPrice::class,
+        'MEA' => MEADimensions::class,
+        'PAC' => PACPackage::class,
+        'GID' => GIDGoodsItemDetails::class,
+        'MOA' => MOAMonetaryAmount::class,
+        'PCI' => PCIPackageId::class,
+        'CNT' => CNTControl::class,
     ];
+
+    /**
+     * The full set of segments typed and registered out of the box: the envelope
+     * plus all business content.
+     *
+     * @var array<string,string>
+     */
+    public const DEFAULT_SEGMENTS = self::ENVELOPE_SEGMENTS + self::BUSINESS_SEGMENTS;
 
     private const TAG_LENGTH = 3;
 

--- a/tests/Unit/Segments/SegmentFactoryTest.php
+++ b/tests/Unit/Segments/SegmentFactoryTest.php
@@ -117,4 +117,35 @@ final class SegmentFactoryTest extends TestCase
         self::assertInstanceOf(UnknownSegment::class, $factory->createSegmentFromArray(['XX']));
         self::assertInstanceOf(UnknownSegment::class, $factory->createSegmentFromArray([]));
     }
+
+    /**
+     * @test
+     */
+    public function envelope_and_business_bundles_partition_the_defaults(): void
+    {
+        // No tag appears in both bundles.
+        self::assertSame(
+            [],
+            array_intersect_key(SegmentFactory::ENVELOPE_SEGMENTS, SegmentFactory::BUSINESS_SEGMENTS),
+        );
+
+        // Their union is exactly the default set.
+        self::assertEqualsCanonicalizing(
+            array_keys(SegmentFactory::DEFAULT_SEGMENTS),
+            array_keys(SegmentFactory::ENVELOPE_SEGMENTS + SegmentFactory::BUSINESS_SEGMENTS),
+        );
+        self::assertCount(7, SegmentFactory::ENVELOPE_SEGMENTS);
+        self::assertCount(32, SegmentFactory::DEFAULT_SEGMENTS);
+    }
+
+    /**
+     * @test
+     */
+    public function an_envelope_only_factory_leaves_business_tags_unknown(): void
+    {
+        $factory = SegmentFactory::withSegments(SegmentFactory::ENVELOPE_SEGMENTS);
+
+        self::assertInstanceOf(UNHMessageHeader::class, $factory->createSegmentFromArray(['UNH']));
+        self::assertInstanceOf(UnknownSegment::class, $factory->createSegmentFromArray(['NAD']));
+    }
 }


### PR DESCRIPTION
## Why

Complete the "richer defaults" work with the composability half. Until now the only way to build a partial factory was to hand-list tags. Splitting the defaults into named bundles lets callers assemble exactly the factory they want — a lean envelope-only parser, or envelope + a handful of business tags — while everything else still parses as a readable `UnknownSegment`.

## What

`SegmentFactory` now exposes two composable, documented bundles:

- `ENVELOPE_SEGMENTS` — the UN* service/control segments (7): `UNB`, `UNG`, `UNH`, `UNS`, `UNT`, `UNE`, `UNZ`.
- `BUSINESS_SEGMENTS` — header, party/terms, detail and summary (25).
- `DEFAULT_SEGMENTS` — now defined as `ENVELOPE_SEGMENTS + BUSINESS_SEGMENTS` (single source of truth, same 32 tags as before).

```php
$factory = SegmentFactory::withSegments(
    SegmentFactory::ENVELOPE_SEGMENTS + [
        'NAD' => NADNameAddress::class,
        'LIN' => LINLineItem::class,
    ],
);
```

Deliberately no per-message-type bundles (ORDERS/INVOIC/…): which business tags belong to which message family is version- and partner-specific, so a curated list there would rot. The two structural bundles are unambiguous.

## Tests / docs

- New tests: bundles partition the defaults (no overlap, union = 32), and an envelope-only factory leaves business tags as `UnknownSegment`.
- **100% coverage held** (229 tests, 632 assertions); the Coverage (100%) gate passes.
- Full gate green: cs-fixer, phpstan, rector.
- README "Composable segment bundles" section + CHANGELOG updated.