### PR TITLE
chore: release 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.4.0] - 2026-07-24
+
 #### Added
 - Composable segment bundles on `SegmentFactory`: `ENVELOPE_SEGMENTS` (the UN*
   service/control segments) and `BUSINESS_SEGMENTS` (header/party/detail/summary).


### PR DESCRIPTION
Release **6.4.0** — composable segment bundles.

### Added
- `SegmentFactory::ENVELOPE_SEGMENTS` and `SegmentFactory::BUSINESS_SEGMENTS` — composable bundles; `DEFAULT_SEGMENTS` is now their union. Build a lean factory with e.g. `withSegments(SegmentFactory::ENVELOPE_SEGMENTS + ['NAD' => ...])`.

Backward-compatible (minor bump from 6.3.0). 100% coverage held.